### PR TITLE
feat: dashboard statistik per role (#18)

### DIFF
--- a/actions/dashboard.actions.ts
+++ b/actions/dashboard.actions.ts
@@ -1,0 +1,257 @@
+'use server'
+
+import { and, count, eq, gte, lte, or, sum } from 'drizzle-orm'
+import Decimal from 'decimal.js'
+import { requireRole, requireSubappAccess } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import {
+  feePayments,
+  institutes,
+  staffs,
+  students,
+  transfers,
+} from '@/lib/db/schema'
+
+type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string }
+
+export type SuperadminStats = {
+  totalInstitutes: number
+  totalStaffs: number
+  totalActiveStudents: number
+  totalPendingTransfers: number
+  totalSppThisMonth: string
+}
+
+export type FoundationStats = {
+  totalFoundationStaffs: number
+  totalOutgoingPendingTransfers: number
+  totalIncomingPendingTransfers: number
+  totalTransferredThisMonth: string
+}
+
+export type SchoolStats = {
+  totalActiveStudents: number
+  totalPendingStudents: number
+  totalUnpaidSppThisMonth: number
+  totalIncomingPendingTransfers: number
+}
+
+/**
+ * Statistik global untuk superadmin dashboard.
+ * Mengambil data dari seluruh institusi tanpa pembatasan.
+ */
+export async function getSuperadminStats(): Promise<ActionResult<SuperadminStats>> {
+  await requireRole(['superadmin'])
+
+  try {
+    const now = new Date()
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999)
+
+    const [
+      totalInstitutesResult,
+      totalStaffsResult,
+      totalActiveStudentsResult,
+      totalPendingTransfersResult,
+      totalSppResult,
+    ] = await Promise.all([
+      db.select({ count: count() }).from(institutes),
+      db.select({ count: count() }).from(staffs).where(eq(staffs.status, 'active')),
+      db.select({ count: count() }).from(students).where(eq(students.status, 'active')),
+      db.select({ count: count() }).from(transfers).where(eq(transfers.status, 'pending')),
+      db
+        .select({ total: sum(feePayments.amountPaid) })
+        .from(feePayments)
+        .where(
+          and(
+            eq(feePayments.status, 'paid'),
+            gte(feePayments.paidDatetime, startOfMonth),
+            lte(feePayments.paidDatetime, endOfMonth),
+          ),
+        ),
+    ])
+
+    const rawTotal = totalSppResult[0]?.total ?? '0'
+    const totalSppThisMonth = new Decimal(rawTotal || '0').toFixed(2)
+
+    return {
+      success: true,
+      data: {
+        totalInstitutes: totalInstitutesResult[0]?.count ?? 0,
+        totalStaffs: totalStaffsResult[0]?.count ?? 0,
+        totalActiveStudents: totalActiveStudentsResult[0]?.count ?? 0,
+        totalPendingTransfers: totalPendingTransfersResult[0]?.count ?? 0,
+        totalSppThisMonth,
+      },
+    }
+  } catch {
+    return { success: false, error: 'Gagal mengambil statistik superadmin.' }
+  }
+}
+
+/**
+ * Statistik untuk foundation admin dashboard.
+ * Di-scope ke yayasan (institusi) milik subapp yang diakses.
+ */
+export async function getFoundationStats(
+  subAppKey: string,
+): Promise<ActionResult<FoundationStats>> {
+  const { subapp } = await requireSubappAccess(subAppKey)
+
+  if (!subapp.instituteId) {
+    return { success: false, error: 'Yayasan belum memiliki institusi yang terkait.' }
+  }
+
+  const instituteId = subapp.instituteId
+
+  try {
+    const now = new Date()
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999)
+
+    const [
+      totalFoundationStaffsResult,
+      totalOutgoingPendingResult,
+      totalIncomingPendingResult,
+      totalTransferredResult,
+    ] = await Promise.all([
+      db
+        .select({ count: count() })
+        .from(staffs)
+        .where(
+          and(eq(staffs.instituteId, instituteId), eq(staffs.status, 'active')),
+        ),
+      db
+        .select({ count: count() })
+        .from(transfers)
+        .where(
+          and(
+            eq(transfers.transferFromId, instituteId),
+            eq(transfers.status, 'pending'),
+          ),
+        ),
+      db
+        .select({ count: count() })
+        .from(transfers)
+        .where(
+          and(
+            eq(transfers.transferToId, instituteId),
+            eq(transfers.status, 'pending'),
+          ),
+        ),
+      db
+        .select({ total: sum(transfers.amount) })
+        .from(transfers)
+        .where(
+          and(
+            or(
+              eq(transfers.transferFromId, instituteId),
+              eq(transfers.transferToId, instituteId),
+            ),
+            eq(transfers.status, 'approved'),
+            gte(transfers.approvedAt, startOfMonth),
+            lte(transfers.approvedAt, endOfMonth),
+          ),
+        ),
+    ])
+
+    const rawTotal = totalTransferredResult[0]?.total ?? '0'
+    const totalTransferredThisMonth = new Decimal(rawTotal || '0').toFixed(2)
+
+    return {
+      success: true,
+      data: {
+        totalFoundationStaffs: totalFoundationStaffsResult[0]?.count ?? 0,
+        totalOutgoingPendingTransfers: totalOutgoingPendingResult[0]?.count ?? 0,
+        totalIncomingPendingTransfers: totalIncomingPendingResult[0]?.count ?? 0,
+        totalTransferredThisMonth,
+      },
+    }
+  } catch {
+    return { success: false, error: 'Gagal mengambil statistik yayasan.' }
+  }
+}
+
+/**
+ * Statistik untuk school admin dashboard.
+ * Di-scope ke sekolah (institusi) milik subapp yang diakses.
+ */
+export async function getSchoolStats(
+  subAppKey: string,
+): Promise<ActionResult<SchoolStats>> {
+  const { subapp } = await requireSubappAccess(subAppKey)
+
+  if (!subapp.instituteId) {
+    return { success: false, error: 'Sekolah belum memiliki institusi yang terkait.' }
+  }
+
+  const instituteId = subapp.instituteId
+
+  try {
+    const now = new Date()
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999)
+
+    const [
+      totalActiveStudentsResult,
+      totalPendingStudentsResult,
+      totalUnpaidSppResult,
+      totalIncomingPendingResult,
+    ] = await Promise.all([
+      db
+        .select({ count: count() })
+        .from(students)
+        .where(
+          and(
+            eq(students.instituteId, instituteId),
+            eq(students.status, 'active'),
+          ),
+        ),
+      db
+        .select({ count: count() })
+        .from(students)
+        .where(
+          and(
+            eq(students.instituteId, instituteId),
+            eq(students.status, 'pending'),
+          ),
+        ),
+      // SPP belum dibayar bulan ini = pembayaran berstatus pending yang dibuat bulan ini
+      db
+        .select({ count: count() })
+        .from(feePayments)
+        .innerJoin(students, eq(feePayments.studentId, students.id))
+        .where(
+          and(
+            eq(students.instituteId, instituteId),
+            eq(feePayments.status, 'pending'),
+            gte(feePayments.createdAt, startOfMonth),
+            lte(feePayments.createdAt, endOfMonth),
+          ),
+        ),
+      db
+        .select({ count: count() })
+        .from(transfers)
+        .where(
+          and(
+            eq(transfers.transferToId, instituteId),
+            eq(transfers.status, 'pending'),
+          ),
+        ),
+    ])
+
+    return {
+      success: true,
+      data: {
+        totalActiveStudents: totalActiveStudentsResult[0]?.count ?? 0,
+        totalPendingStudents: totalPendingStudentsResult[0]?.count ?? 0,
+        totalUnpaidSppThisMonth: totalUnpaidSppResult[0]?.count ?? 0,
+        totalIncomingPendingTransfers: totalIncomingPendingResult[0]?.count ?? 0,
+      },
+    }
+  } catch {
+    return { success: false, error: 'Gagal mengambil statistik sekolah.' }
+  }
+}

--- a/app/(dashboard)/foundation/[subAppKey]/page.tsx
+++ b/app/(dashboard)/foundation/[subAppKey]/page.tsx
@@ -1,5 +1,14 @@
 import { redirect } from 'next/navigation'
+import {
+  Users,
+  ArrowUpRight,
+  ArrowDownLeft,
+  Banknote,
+} from 'lucide-react'
 import { requireSubappAccess } from '@/lib/auth-helpers'
+import { getFoundationStats } from '@/actions/dashboard.actions'
+import { StatCard } from '@/components/dashboard/stat-card'
+import { formatRupiah } from '@/lib/utils'
 
 export async function generateMetadata({
   params,
@@ -28,16 +37,55 @@ export default async function FoundationSubappPage({
     redirect('/login')
   }
 
+  const statsResult = await getFoundationStats(subAppKey).catch(() => null)
+
+  const stats = statsResult?.success ? statsResult.data : null
+
+  const now = new Date()
+  const monthName = now.toLocaleString('id-ID', { month: 'long', year: 'numeric' })
+
   return (
-    <div className="flex flex-col gap-4">
-      <h1 className="text-2xl font-semibold tracking-tight">
-        Dashboard Yayasan
-      </h1>
-      <p className="text-muted-foreground">
-        Selamat datang di dashboard{' '}
-        <span className="font-medium text-foreground">{subappName}</span>.
-        Fitur lengkap sedang dalam pengembangan.
-      </p>
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Dashboard Yayasan</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Ringkasan statistik{' '}
+          <span className="text-foreground font-medium">{subappName}</span>.
+        </p>
+      </div>
+
+      {statsResult && !statsResult.success && (
+        <p className="text-destructive text-sm">{statsResult.error}</p>
+      )}
+
+      {stats && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-2">
+          <StatCard
+            title="Total Staf Yayasan"
+            value={stats.totalFoundationStaffs}
+            description="Staf aktif di yayasan ini"
+            icon={Users}
+          />
+          <StatCard
+            title="Transfer Keluar Pending"
+            value={stats.totalOutgoingPendingTransfers}
+            description="Transfer dari yayasan ini yang belum disetujui"
+            icon={ArrowUpRight}
+          />
+          <StatCard
+            title="Transfer Masuk Pending"
+            value={stats.totalIncomingPendingTransfers}
+            description="Transfer ke yayasan ini yang belum disetujui"
+            icon={ArrowDownLeft}
+          />
+          <StatCard
+            title={`Total Dana Ditransfer Bulan Ini`}
+            value={formatRupiah(stats.totalTransferredThisMonth)}
+            description={`Transfer disetujui — ${monthName}`}
+            icon={Banknote}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/app/(dashboard)/school/[subAppKey]/page.tsx
+++ b/app/(dashboard)/school/[subAppKey]/page.tsx
@@ -1,5 +1,13 @@
 import { redirect } from 'next/navigation'
+import {
+  GraduationCap,
+  Clock,
+  Receipt,
+  ArrowDownLeft,
+} from 'lucide-react'
 import { requireSubappAccess } from '@/lib/auth-helpers'
+import { getSchoolStats } from '@/actions/dashboard.actions'
+import { StatCard } from '@/components/dashboard/stat-card'
 
 export async function generateMetadata({
   params,
@@ -28,16 +36,55 @@ export default async function SchoolSubappPage({
     redirect('/login')
   }
 
+  const statsResult = await getSchoolStats(subAppKey).catch(() => null)
+
+  const stats = statsResult?.success ? statsResult.data : null
+
+  const now = new Date()
+  const monthName = now.toLocaleString('id-ID', { month: 'long', year: 'numeric' })
+
   return (
-    <div className="flex flex-col gap-4">
-      <h1 className="text-2xl font-semibold tracking-tight">
-        Dashboard Sekolah
-      </h1>
-      <p className="text-muted-foreground">
-        Selamat datang di dashboard{' '}
-        <span className="font-medium text-foreground">{subappName}</span>.
-        Fitur lengkap sedang dalam pengembangan.
-      </p>
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Dashboard Sekolah</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Ringkasan statistik{' '}
+          <span className="text-foreground font-medium">{subappName}</span>.
+        </p>
+      </div>
+
+      {statsResult && !statsResult.success && (
+        <p className="text-destructive text-sm">{statsResult.error}</p>
+      )}
+
+      {stats && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-2">
+          <StatCard
+            title="Siswa Aktif"
+            value={stats.totalActiveStudents}
+            description="Siswa berstatus aktif di sekolah ini"
+            icon={GraduationCap}
+          />
+          <StatCard
+            title="Siswa Pending"
+            value={stats.totalPendingStudents}
+            description="Siswa menunggu aktivasi"
+            icon={Clock}
+          />
+          <StatCard
+            title={`SPP Belum Dibayar Bulan Ini`}
+            value={stats.totalUnpaidSppThisMonth}
+            description={`Tagihan SPP pending — ${monthName}`}
+            icon={Receipt}
+          />
+          <StatCard
+            title="Transfer Masuk Pending"
+            value={stats.totalIncomingPendingTransfers}
+            description="Transfer dana ke sekolah ini yang belum disetujui"
+            icon={ArrowDownLeft}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/app/(dashboard)/superadmin/page.tsx
+++ b/app/(dashboard)/superadmin/page.tsx
@@ -1,5 +1,15 @@
 import { redirect } from 'next/navigation'
+import {
+  Building2,
+  Users,
+  GraduationCap,
+  ArrowLeftRight,
+  Banknote,
+} from 'lucide-react'
 import { requireRole } from '@/lib/auth-helpers'
+import { getSuperadminStats } from '@/actions/dashboard.actions'
+import { StatCard } from '@/components/dashboard/stat-card'
+import { formatRupiah } from '@/lib/utils'
 
 export const metadata = {
   title: 'Superadmin Panel — School ERP',
@@ -12,12 +22,60 @@ export default async function SuperadminDashboardPage() {
     redirect('/login')
   }
 
+  const statsResult = await getSuperadminStats()
+
+  const stats = statsResult.success ? statsResult.data : null
+
+  const now = new Date()
+  const monthName = now.toLocaleString('id-ID', { month: 'long', year: 'numeric' })
+
   return (
-    <div className="flex flex-col gap-4">
-      <h1 className="text-2xl font-semibold tracking-tight">Superadmin Panel</h1>
-      <p className="text-muted-foreground">
-        Selamat datang di panel superadmin. Gunakan menu di sidebar untuk mengelola sistem.
-      </p>
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Superadmin Panel</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Ringkasan statistik seluruh sistem.
+        </p>
+      </div>
+
+      {!statsResult.success && (
+        <p className="text-destructive text-sm">{statsResult.error}</p>
+      )}
+
+      {stats && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <StatCard
+            title="Total Institusi"
+            value={stats.totalInstitutes}
+            description="Semua yayasan dan sekolah terdaftar"
+            icon={Building2}
+          />
+          <StatCard
+            title="Total Staf Aktif"
+            value={stats.totalStaffs}
+            description="Staf berstatus aktif di seluruh institusi"
+            icon={Users}
+          />
+          <StatCard
+            title="Total Siswa Aktif"
+            value={stats.totalActiveStudents}
+            description="Siswa berstatus aktif di seluruh sekolah"
+            icon={GraduationCap}
+          />
+          <StatCard
+            title="Transfer Pending"
+            value={stats.totalPendingTransfers}
+            description="Transfer dana menunggu persetujuan"
+            icon={ArrowLeftRight}
+          />
+          <StatCard
+            title={`Total SPP Bulan Ini`}
+            value={formatRupiah(stats.totalSppThisMonth)}
+            description={`Pembayaran SPP terkonfirmasi — ${monthName}`}
+            icon={Banknote}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/components/dashboard/stat-card.tsx
+++ b/components/dashboard/stat-card.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { type LucideIcon } from 'lucide-react'
+
+type StatCardProps = {
+  title: string
+  value: string | number
+  description?: string
+  icon: LucideIcon
+}
+
+export function StatCard({ title, value, description, icon: Icon }: StatCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="text-muted-foreground h-4 w-4" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        {description && (
+          <p className="text-muted-foreground mt-1 text-xs">{description}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Format angka atau string numerik ke format Rupiah Indonesia.
+ * Contoh: "1500000.00" → "Rp 1.500.000"
+ */
+export function formatRupiah(value: string | number): string {
+  const num = typeof value === 'string' ? parseFloat(value) : value
+  if (isNaN(num)) return 'Rp 0'
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(num)
+}


### PR DESCRIPTION
## Terkait Issue
Closes #18

## Ringkasan Perubahan
- Buat `actions/dashboard.actions.ts` — Server Actions untuk query agregasi statistik per role (superadmin, foundation, school) dengan data isolation penuh
- Buat `components/dashboard/stat-card.tsx` — komponen kartu statistik reusable menggunakan shadcn/ui Card
- Isi `/superadmin/page.tsx` — 5 stat cards: total institusi, staf aktif, siswa aktif, transfer pending, SPP bulan ini
- Isi `/foundation/[subAppKey]/page.tsx` — 4 stat cards di-scope ke yayasan: staf, transfer keluar/masuk pending, dana ditransfer bulan ini
- Isi `/school/[subAppKey]/page.tsx` — 4 stat cards di-scope ke sekolah: siswa aktif, siswa pending, SPP belum dibayar, transfer masuk pending
- Tambah `formatRupiah()` helper di `lib/utils.ts` untuk tampilan nilai uang dalam format Rupiah

## Hasil Test Plan
- `pnpm tsc --noEmit` → EXIT: 0 (tidak ada error TypeScript)
- `pnpm build` → BUILD EXIT: 0 (build berhasil, semua 33 routes terkompilasi)

## Checklist
- [x] `/superadmin/page.tsx` diisi dengan card statistik superadmin
- [x] `/foundation/[subAppKey]/page.tsx` — di-scope ke yayasan via `requireSubappAccess`
- [x] `/school/[subAppKey]/page.tsx` — di-scope ke sekolah via `requireSubappAccess`
- [x] Server Actions untuk query agregasi per dashboard dibuat di `dashboard.actions.ts`
- [x] Nilai uang ditampilkan dalam format Rupiah via `formatRupiah()`
- [x] Data isolation: superadmin = global, foundation/school = hanya institusinya
- [x] Tidak ada `any` di TypeScript
- [x] Semua Server Action dimulai dengan `requireRole` atau `requireSubappAccess`
- [x] Error message dalam Bahasa Indonesia