### PR TITLE
feat: pencarian & filter dengan URL search params (#19)

### DIFF
--- a/actions/fee.actions.ts
+++ b/actions/fee.actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { and, count, eq, sql } from 'drizzle-orm'
+import { and, count, eq, sql, desc } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
 import Decimal from 'decimal.js'
 import { requireRole, requireSubappAccess } from '@/lib/auth-helpers'
@@ -33,16 +33,30 @@ export async function getFees(
   const parsed = getFeesSchema.safeParse({
     page: input.page ?? 1,
     perPage: input.perPage ?? 10,
+    feeType: input.feeType,
+    year: input.year,
   })
 
   if (!parsed.success) {
     return { success: false, error: 'Parameter tidak valid.' }
   }
 
-  const { page, perPage } = parsed.data
+  const { page, perPage, feeType, year } = parsed.data
   const offset = (page - 1) * perPage
 
   try {
+    const conditions = []
+
+    if (feeType) {
+      conditions.push(eq(fees.feeType, feeType))
+    }
+
+    if (year) {
+      conditions.push(eq(fees.year, year))
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined
+
     const rows = await db
       .select({
         id: fees.id,
@@ -55,12 +69,13 @@ export async function getFees(
       })
       .from(fees)
       .leftJoin(feePayments, eq(feePayments.feeId, fees.id))
+      .where(whereClause)
       .groupBy(fees.id)
-      .orderBy(fees.year, fees.feeType)
+      .orderBy(desc(fees.year), fees.feeType)
       .limit(perPage)
       .offset(offset)
 
-    const totalResult = await db.select({ count: count() }).from(fees)
+    const totalResult = await db.select({ count: count() }).from(fees).where(whereClause)
     const total = totalResult[0]?.count ?? 0
 
     const data: FeeRow[] = rows.map((row) => ({
@@ -76,6 +91,24 @@ export async function getFees(
     return { success: true, data: { data, total, page, perPage } }
   } catch {
     return { success: false, error: 'Gagal mengambil data tarif biaya. Silakan coba lagi.' }
+  }
+}
+
+/**
+ * Mengambil daftar tahun yang tersedia dari tarif biaya (untuk filter).
+ */
+export async function getFeeYears(): Promise<ActionResult<number[]>> {
+  await requireRole(['superadmin'])
+
+  try {
+    const rows = await db
+      .selectDistinct({ year: fees.year })
+      .from(fees)
+      .orderBy(desc(fees.year))
+
+    return { success: true, data: rows.map((r) => r.year) }
+  } catch {
+    return { success: false, error: 'Gagal mengambil data tahun biaya.' }
   }
 }
 

--- a/actions/staff.actions.ts
+++ b/actions/staff.actions.ts
@@ -9,6 +9,8 @@ import {
   createStaffSchema,
   updateStaffSchema,
   getStaffsSchema,
+  type StaffStatus,
+  type StaffDepartment,
   type CreateStaffInput,
   type UpdateStaffInput,
   type GetStaffsInput,
@@ -51,6 +53,8 @@ export async function getStaffs(
     page: input.page ?? 1,
     perPage: input.perPage ?? 10,
     search: input.search,
+    status: input.status,
+    department: input.department,
     instituteId: scopedInstituteId,
   })
 
@@ -58,7 +62,7 @@ export async function getStaffs(
     return { success: false, error: 'Parameter tidak valid.' }
   }
 
-  const { page, perPage, search } = parsed.data
+  const { page, perPage, search, status, department } = parsed.data
   const offset = (page - 1) * perPage
 
   try {
@@ -66,6 +70,14 @@ export async function getStaffs(
 
     if (scopedInstituteId) {
       conditions.push(eq(staffs.instituteId, scopedInstituteId))
+    }
+
+    if (status) {
+      conditions.push(eq(staffs.status, status as StaffStatus))
+    }
+
+    if (department) {
+      conditions.push(eq(staffs.department, department as StaffDepartment))
     }
 
     if (search) {

--- a/app/(dashboard)/foundation/[subAppKey]/staffs/page.tsx
+++ b/app/(dashboard)/foundation/[subAppKey]/staffs/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireSubappAccess } from '@/lib/auth-helpers'
 import { StaffsListClient } from '@/components/staffs/staffs-list-client'
@@ -39,10 +40,12 @@ export default async function FoundationStaffsPage({ params }: FoundationStaffsP
         </p>
       </div>
 
-      <StaffsListClient
-        subAppKey={subAppKey}
-        instituteId={instituteId}
-      />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <StaffsListClient
+          subAppKey={subAppKey}
+          instituteId={instituteId}
+        />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/foundation/[subAppKey]/transfers/page.tsx
+++ b/app/(dashboard)/foundation/[subAppKey]/transfers/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireSubappAccess } from '@/lib/auth-helpers'
 import { TransfersListClient } from '@/components/transfers/transfers-list-client'
@@ -39,12 +40,14 @@ export default async function FoundationTransfersPage({ params }: FoundationTran
         </p>
       </div>
 
-      <TransfersListClient
-        subAppKey={subAppKey}
-        subappType="foundation"
-        scopedInstituteId={scopedInstituteId}
-        basePath={`/foundation/${subAppKey}/transfers`}
-      />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <TransfersListClient
+          subAppKey={subAppKey}
+          subappType="foundation"
+          scopedInstituteId={scopedInstituteId}
+          basePath={`/foundation/${subAppKey}/transfers`}
+        />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/school/[subAppKey]/fee-payments/page.tsx
+++ b/app/(dashboard)/school/[subAppKey]/fee-payments/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireSubappAccess } from '@/lib/auth-helpers'
 import { FeePaymentsListClient } from '@/components/fee-payments/fee-payments-list-client'
@@ -35,7 +36,9 @@ export default async function SchoolFeePaymentsPage({ params }: SchoolFeePayment
         </p>
       </div>
 
-      <FeePaymentsListClient subAppKey={subAppKey} />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <FeePaymentsListClient subAppKey={subAppKey} />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/school/[subAppKey]/staffs/page.tsx
+++ b/app/(dashboard)/school/[subAppKey]/staffs/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireSubappAccess } from '@/lib/auth-helpers'
 import { StaffsListClient } from '@/components/staffs/staffs-list-client'
@@ -39,10 +40,12 @@ export default async function SchoolStaffsPage({ params }: SchoolStaffsPageProps
         </p>
       </div>
 
-      <StaffsListClient
-        subAppKey={subAppKey}
-        instituteId={instituteId}
-      />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <StaffsListClient
+          subAppKey={subAppKey}
+          instituteId={instituteId}
+        />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/school/[subAppKey]/students/page.tsx
+++ b/app/(dashboard)/school/[subAppKey]/students/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireSubappAccess } from '@/lib/auth-helpers'
 import { StudentsListClient } from '@/components/students/students-list-client'
@@ -39,10 +40,12 @@ export default async function SchoolStudentsPage({ params }: SchoolStudentsPageP
         </p>
       </div>
 
-      <StudentsListClient
-        subAppKey={subAppKey}
-        instituteId={instituteId}
-      />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <StudentsListClient
+          subAppKey={subAppKey}
+          instituteId={instituteId}
+        />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/school/[subAppKey]/transfers/page.tsx
+++ b/app/(dashboard)/school/[subAppKey]/transfers/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireSubappAccess } from '@/lib/auth-helpers'
 import { TransfersListClient } from '@/components/transfers/transfers-list-client'
@@ -39,12 +40,14 @@ export default async function SchoolTransfersPage({ params }: SchoolTransfersPag
         </p>
       </div>
 
-      <TransfersListClient
-        subAppKey={subAppKey}
-        subappType="school"
-        scopedInstituteId={scopedInstituteId}
-        basePath={`/school/${subAppKey}/transfers`}
-      />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <TransfersListClient
+          subAppKey={subAppKey}
+          subappType="school"
+          scopedInstituteId={scopedInstituteId}
+          basePath={`/school/${subAppKey}/transfers`}
+        />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/superadmin/fee-payments/page.tsx
+++ b/app/(dashboard)/superadmin/fee-payments/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireRole } from '@/lib/auth-helpers'
 import { FeePaymentsListClient } from '@/components/fee-payments/fee-payments-list-client'
@@ -22,7 +23,9 @@ export default async function SuperadminFeePaymentsPage() {
         </p>
       </div>
 
-      <FeePaymentsListClient />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <FeePaymentsListClient />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/superadmin/fees/page.tsx
+++ b/app/(dashboard)/superadmin/fees/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireRole } from '@/lib/auth-helpers'
 import { FeesListClient } from '@/components/fees/fees-list-client'
@@ -22,7 +23,9 @@ export default async function SuperadminFeesPage() {
         </p>
       </div>
 
-      <FeesListClient />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <FeesListClient />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/superadmin/institutes/page.tsx
+++ b/app/(dashboard)/superadmin/institutes/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireRole } from '@/lib/auth-helpers'
 import { InstitutesListClient } from '@/components/institutes/institutes-list-client'
@@ -22,7 +23,9 @@ export default async function InstitutesPage() {
         </p>
       </div>
 
-      <InstitutesListClient />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <InstitutesListClient />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/superadmin/staffs/page.tsx
+++ b/app/(dashboard)/superadmin/staffs/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireRole } from '@/lib/auth-helpers'
 import { StaffsListClient } from '@/components/staffs/staffs-list-client'
@@ -22,7 +23,9 @@ export default async function SuperadminStaffsPage() {
         </p>
       </div>
 
-      <StaffsListClient isSuperadmin showInstitute />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <StaffsListClient isSuperadmin showInstitute />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/superadmin/students/page.tsx
+++ b/app/(dashboard)/superadmin/students/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireRole } from '@/lib/auth-helpers'
 import { StudentsListClient } from '@/components/students/students-list-client'
@@ -22,7 +23,9 @@ export default async function SuperadminStudentsPage() {
         </p>
       </div>
 
-      <StudentsListClient isSuperadmin showInstitute />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <StudentsListClient isSuperadmin showInstitute />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/superadmin/transfers/page.tsx
+++ b/app/(dashboard)/superadmin/transfers/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { requireRole } from '@/lib/auth-helpers'
 import { TransfersListClient } from '@/components/transfers/transfers-list-client'
@@ -22,7 +23,9 @@ export default async function SuperadminTransfersPage() {
         </p>
       </div>
 
-      <TransfersListClient basePath="/superadmin/transfers" />
+      <Suspense fallback={<div className="rounded-md border p-8 text-center text-muted-foreground text-sm">Memuat data...</div>}>
+        <TransfersListClient basePath="/superadmin/transfers" />
+      </Suspense>
     </div>
   )
 }

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { UrlPagination } from './url-pagination'
+
+export interface ColumnDef<TData> {
+  key: string
+  header: string
+  cell: (row: TData) => React.ReactNode
+  className?: string
+}
+
+interface DataTableProps<TData> {
+  data: TData[]
+  columns: ColumnDef<TData>[]
+  total: number
+  page: number
+  perPage: number
+  itemLabel?: string
+  emptyText?: string
+  getRowKey: (row: TData) => string
+}
+
+export function DataTable<TData>({
+  data,
+  columns,
+  total,
+  page,
+  perPage,
+  itemLabel = 'data',
+  emptyText = 'Belum ada data.',
+  getRowKey,
+}: DataTableProps<TData>) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {columns.map((col) => (
+                <TableHead key={col.key} className={col.className}>
+                  {col.header}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="text-center text-muted-foreground py-10"
+                >
+                  {emptyText}
+                </TableCell>
+              </TableRow>
+            ) : (
+              data.map((row) => (
+                <TableRow key={getRowKey(row)}>
+                  {columns.map((col) => (
+                    <TableCell key={col.key} className={col.className}>
+                      {col.cell(row)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <UrlPagination
+        total={total}
+        page={page}
+        perPage={perPage}
+        itemLabel={itemLabel}
+      />
+    </div>
+  )
+}

--- a/components/data-table/filter-select.tsx
+++ b/components/data-table/filter-select.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+interface FilterOption {
+  value: string
+  label: string
+}
+
+interface FilterSelectProps {
+  options: FilterOption[]
+  paramKey: string
+  placeholder?: string
+  className?: string
+}
+
+export function FilterSelect({
+  options,
+  paramKey,
+  placeholder = 'Semua',
+  className,
+}: FilterSelectProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const currentValue = searchParams.get(paramKey) ?? 'all'
+
+  function handleChange(value: string | null) {
+    const params = new URLSearchParams(searchParams.toString())
+
+    if (value && value !== 'all') {
+      params.set(paramKey, value)
+    } else {
+      params.delete(paramKey)
+    }
+
+    // Reset page ke 1 saat filter berubah
+    params.set('page', '1')
+
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  return (
+    <Select value={currentValue} onValueChange={handleChange}>
+      <SelectTrigger className={className ?? 'w-[160px]'}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((opt) => (
+          <SelectItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/components/data-table/index.ts
+++ b/components/data-table/index.ts
@@ -1,0 +1,5 @@
+export { DataTable } from './data-table'
+export type { ColumnDef } from './data-table'
+export { SearchInput } from './search-input'
+export { FilterSelect } from './filter-select'
+export { UrlPagination } from './url-pagination'

--- a/components/data-table/search-input.tsx
+++ b/components/data-table/search-input.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { SearchIcon, XIcon } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+interface SearchInputProps {
+  placeholder?: string
+  paramKey?: string
+  className?: string
+}
+
+export function SearchInput({
+  placeholder = 'Cari...',
+  paramKey = 'search',
+  className,
+}: SearchInputProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const initialValue = searchParams.get(paramKey) ?? ''
+  const [value, setValue] = useState(initialValue)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Sync from URL to local state on navigation
+  useEffect(() => {
+    const urlValue = searchParams.get(paramKey) ?? ''
+    setValue(urlValue)
+  }, [searchParams, paramKey])
+
+  function updateUrl(newValue: string) {
+    const params = new URLSearchParams(searchParams.toString())
+
+    if (newValue) {
+      params.set(paramKey, newValue)
+    } else {
+      params.delete(paramKey)
+    }
+
+    // Reset page ke 1 saat search berubah
+    params.set('page', '1')
+
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newValue = e.target.value
+    setValue(newValue)
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+    }
+
+    debounceRef.current = setTimeout(() => {
+      updateUrl(newValue)
+    }, 300)
+  }
+
+  function handleClear() {
+    setValue('')
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+    }
+    updateUrl('')
+  }
+
+  return (
+    <div className={`relative flex-1 ${className ?? ''}`}>
+      <SearchIcon className="absolute left-2.5 top-2.5 size-4 text-muted-foreground pointer-events-none" />
+      <Input
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        className="pl-8 pr-8"
+      />
+      {value && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute right-1 top-1 size-6 text-muted-foreground hover:text-foreground"
+          onClick={handleClear}
+        >
+          <XIcon className="size-3" />
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/components/data-table/url-pagination.tsx
+++ b/components/data-table/url-pagination.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+
+interface UrlPaginationProps {
+  total: number
+  page: number
+  perPage: number
+  itemLabel?: string
+}
+
+export function UrlPagination({
+  total,
+  page,
+  perPage,
+  itemLabel = 'data',
+}: UrlPaginationProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const totalPages = Math.ceil(total / perPage)
+  const from = total === 0 ? 0 : (page - 1) * perPage + 1
+  const to = Math.min(page * perPage, total)
+
+  function goToPage(newPage: number) {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('page', String(newPage))
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  if (total === 0) return null
+
+  return (
+    <div className="flex items-center justify-between pt-4">
+      <p className="text-sm text-muted-foreground">
+        Menampilkan {from}–{to} dari {total} {itemLabel}
+      </p>
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page <= 1}
+          onClick={() => goToPage(page - 1)}
+        >
+          Sebelumnya
+        </Button>
+        <span className="flex items-center px-2 text-sm text-muted-foreground">
+          {page} / {totalPages}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page >= totalPages}
+          onClick={() => goToPage(page + 1)}
+        >
+          Berikutnya
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/fee-payments/fee-payments-list-client.tsx
+++ b/components/fee-payments/fee-payments-list-client.tsx
@@ -1,17 +1,10 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { PlusIcon, SearchIcon } from 'lucide-react'
+import { useSearchParams } from 'next/navigation'
+import { PlusIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import {
   Sheet,
   SheetContent,
@@ -19,16 +12,18 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
+import { SearchInput } from '@/components/data-table/search-input'
+import { FilterSelect } from '@/components/data-table/filter-select'
 import { FeePaymentsTable } from './fee-payments-table'
 import { FeePaymentForm } from './fee-payment-form'
-import { getFeePayments } from '@/actions/fee-payment.actions'
+import { getFeePayments, getFeeYears } from '@/actions/fee-payment.actions'
 import type { FeePaymentRow, PaymentStatus, PaymentMethod } from '@/lib/validations/fee-payment'
 
 interface FeePaymentsListClientProps {
   subAppKey?: string
 }
 
-const statusOptions: { value: PaymentStatus | 'all'; label: string }[] = [
+const statusOptions = [
   { value: 'all', label: 'Semua Status' },
   { value: 'pending', label: 'Pending' },
   { value: 'paid', label: 'Lunas' },
@@ -36,7 +31,7 @@ const statusOptions: { value: PaymentStatus | 'all'; label: string }[] = [
   { value: 'refunded', label: 'Dikembalikan' },
 ]
 
-const methodOptions: { value: PaymentMethod | 'all'; label: string }[] = [
+const methodOptions = [
   { value: 'all', label: 'Semua Metode' },
   { value: 'cash', label: 'Tunai' },
   { value: 'transfer', label: 'Transfer' },
@@ -46,118 +41,110 @@ const methodOptions: { value: PaymentMethod | 'all'; label: string }[] = [
 ]
 
 export function FeePaymentsListClient({ subAppKey }: FeePaymentsListClientProps) {
+  const searchParams = useSearchParams()
+
+  const search = searchParams.get('search') ?? ''
+  const statusFilter = searchParams.get('status') ?? 'all'
+  const methodFilter = searchParams.get('method') ?? 'all'
+  const feeYearFilter = searchParams.get('feeYear') ?? 'all'
+  const page = Number(searchParams.get('page') ?? '1')
+
   const [data, setData] = useState<FeePaymentRow[]>([])
   const [total, setTotal] = useState(0)
-  const [page, setPage] = useState(1)
-  const [search, setSearch] = useState('')
-  const [statusFilter, setStatusFilter] = useState<PaymentStatus | 'all'>('all')
-  const [methodFilter, setMethodFilter] = useState<PaymentMethod | 'all'>('all')
   const [loading, setLoading] = useState(true)
+  const [availableYears, setAvailableYears] = useState<number[]>([])
 
   const [sheetOpen, setSheetOpen] = useState(false)
 
   const perPage = 10
 
-  const fetchData = useCallback(
-    async (
-      currentPage: number,
-      currentSearch: string,
-      currentStatus: PaymentStatus | 'all',
-      currentMethod: PaymentMethod | 'all',
-    ) => {
-      setLoading(true)
-      try {
-        const result = await getFeePayments(
-          {
-            page: currentPage,
-            perPage,
-            search: currentSearch || undefined,
-            status: currentStatus !== 'all' ? currentStatus : undefined,
-            paymentMethod: currentMethod !== 'all' ? currentMethod : undefined,
-          },
-          subAppKey,
-        )
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const result = await getFeePayments(
+        {
+          page,
+          perPage,
+          search: search || undefined,
+          status: statusFilter !== 'all' ? (statusFilter as PaymentStatus) : undefined,
+          paymentMethod: methodFilter !== 'all' ? (methodFilter as PaymentMethod) : undefined,
+          feeYear: feeYearFilter !== 'all' ? Number(feeYearFilter) : undefined,
+        },
+        subAppKey,
+      )
 
-        if (result.success) {
-          setData(result.data.data)
-          setTotal(result.data.total)
-        } else {
-          toast.error(result.error)
-        }
-      } catch {
-        toast.error('Gagal memuat data pembayaran.')
-      } finally {
-        setLoading(false)
+      if (result.success) {
+        setData(result.data.data)
+        setTotal(result.data.total)
+      } else {
+        toast.error(result.error)
       }
-    },
-    [subAppKey],
-  )
+    } catch {
+      toast.error('Gagal memuat data pembayaran.')
+    } finally {
+      setLoading(false)
+    }
+  }, [page, search, statusFilter, methodFilter, feeYearFilter, subAppKey])
 
-  // Debounce search
+  const fetchYears = useCallback(async () => {
+    try {
+      const result = await getFeeYears(subAppKey)
+      if (result.success) {
+        setAvailableYears(result.data)
+      }
+    } catch {
+      // silent — non-critical
+    }
+  }, [subAppKey])
+
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      setPage(1)
-      fetchData(1, search, statusFilter, methodFilter)
-    }, 400)
-    return () => clearTimeout(timeout)
-  }, [search, statusFilter, methodFilter, fetchData])
+    fetchData()
+  }, [fetchData])
 
-  function handlePageChange(newPage: number) {
-    setPage(newPage)
-    fetchData(newPage, search, statusFilter, methodFilter)
-  }
+  useEffect(() => {
+    fetchYears()
+  }, [fetchYears])
 
   function handleFormSuccess() {
     setSheetOpen(false)
-    fetchData(page, search, statusFilter, methodFilter)
+    fetchData()
   }
+
+  const yearOptions = [
+    { value: 'all', label: 'Semua Tahun' },
+    ...availableYears.map((y) => ({ value: String(y), label: String(y) })),
+  ]
 
   return (
     <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
-          <div className="relative flex-1 max-w-sm">
-            <SearchIcon className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
-            <Input
-              placeholder="Cari nama siswa atau no. siswa..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-8"
+          <SearchInput
+            placeholder="Cari nama siswa atau no. siswa..."
+            paramKey="search"
+            className="max-w-sm"
+          />
+          <FilterSelect
+            options={statusOptions}
+            paramKey="status"
+            placeholder="Semua Status"
+            className="w-[160px]"
+          />
+          <FilterSelect
+            options={methodOptions}
+            paramKey="method"
+            placeholder="Semua Metode"
+            className="w-[160px]"
+          />
+          {availableYears.length > 0 && (
+            <FilterSelect
+              options={yearOptions}
+              paramKey="feeYear"
+              placeholder="Semua Tahun"
+              className="w-[140px]"
             />
-          </div>
-
-          <Select
-            value={statusFilter}
-            onValueChange={(val) => setStatusFilter(val as PaymentStatus | 'all')}
-          >
-            <SelectTrigger className="w-full sm:w-[160px]">
-              <SelectValue placeholder="Semua Status" />
-            </SelectTrigger>
-            <SelectContent>
-              {statusOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          <Select
-            value={methodFilter}
-            onValueChange={(val) => setMethodFilter(val as PaymentMethod | 'all')}
-          >
-            <SelectTrigger className="w-full sm:w-[160px]">
-              <SelectValue placeholder="Semua Metode" />
-            </SelectTrigger>
-            <SelectContent>
-              {methodOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          )}
         </div>
 
         <Button onClick={() => setSheetOpen(true)}>
@@ -177,8 +164,7 @@ export function FeePaymentsListClient({ subAppKey }: FeePaymentsListClientProps)
           total={total}
           page={page}
           perPage={perPage}
-          onPageChange={handlePageChange}
-          onRefresh={() => fetchData(page, search, statusFilter, methodFilter)}
+          onRefresh={fetchData}
           subAppKey={subAppKey}
         />
       )}

--- a/components/fee-payments/fee-payments-table.tsx
+++ b/components/fee-payments/fee-payments-table.tsx
@@ -21,6 +21,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { UrlPagination } from '@/components/data-table/url-pagination'
 import { confirmPayment } from '@/actions/fee-payment.actions'
 import type { FeePaymentRow, PaymentStatus, PaymentMethod } from '@/lib/validations/fee-payment'
 
@@ -29,7 +30,6 @@ interface FeePaymentsTableProps {
   total: number
   page: number
   perPage: number
-  onPageChange: (page: number) => void
   onRefresh: () => void
   subAppKey?: string
 }
@@ -87,14 +87,11 @@ export function FeePaymentsTable({
   total,
   page,
   perPage,
-  onPageChange,
   onRefresh,
   subAppKey,
 }: FeePaymentsTableProps) {
   const [isPending, startTransition] = useTransition()
   const [confirmTarget, setConfirmTarget] = useState<FeePaymentRow | null>(null)
-
-  const totalPages = Math.ceil(total / perPage)
 
   const handleConfirm = useCallback(() => {
     if (!confirmTarget) return
@@ -204,32 +201,12 @@ export function FeePaymentsTable({
       </div>
 
       {/* Paginasi */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-4">
-          <p className="text-sm text-muted-foreground">
-            Menampilkan {(page - 1) * perPage + 1}–{Math.min(page * perPage, total)} dari {total}{' '}
-            pembayaran
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page <= 1 || isPending}
-              onClick={() => onPageChange(page - 1)}
-            >
-              Sebelumnya
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages || isPending}
-              onClick={() => onPageChange(page + 1)}
-            >
-              Berikutnya
-            </Button>
-          </div>
-        </div>
-      )}
+      <UrlPagination
+        total={total}
+        page={page}
+        perPage={perPage}
+        itemLabel="pembayaran"
+      />
 
       {/* Dialog konfirmasi pembayaran */}
       <Dialog open={!!confirmTarget} onOpenChange={(open) => !open && setConfirmTarget(null)}>

--- a/components/fees/fees-list-client.tsx
+++ b/components/fees/fees-list-client.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { PlusIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -11,26 +12,43 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
+import { FilterSelect } from '@/components/data-table/filter-select'
 import { FeesTable } from './fees-table'
 import { FeeForm } from './fee-form'
-import { getFees } from '@/actions/fee.actions'
-import type { FeeRow } from '@/lib/validations/fee'
+import { getFees, getFeeYears } from '@/actions/fee.actions'
+import type { FeeRow, FeeType } from '@/lib/validations/fee'
+
+const feeTypeOptions = [
+  { value: 'all', label: 'Semua Tipe' },
+  { value: 'spp', label: 'SPP' },
+]
 
 export function FeesListClient() {
+  const searchParams = useSearchParams()
+
+  const feeTypeFilter = searchParams.get('feeType') ?? 'all'
+  const yearFilter = searchParams.get('year') ?? 'all'
+  const page = Number(searchParams.get('page') ?? '1')
+
   const [data, setData] = useState<FeeRow[]>([])
   const [total, setTotal] = useState(0)
-  const [page, setPage] = useState(1)
   const [loading, setLoading] = useState(true)
+  const [availableYears, setAvailableYears] = useState<number[]>([])
 
   const [sheetOpen, setSheetOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<FeeRow | null>(null)
 
   const perPage = 10
 
-  const fetchData = useCallback(async (currentPage: number) => {
+  const fetchData = useCallback(async () => {
     setLoading(true)
     try {
-      const result = await getFees({ page: currentPage, perPage })
+      const result = await getFees({
+        page,
+        perPage,
+        feeType: feeTypeFilter !== 'all' ? (feeTypeFilter as FeeType) : undefined,
+        year: yearFilter !== 'all' ? Number(yearFilter) : undefined,
+      })
 
       if (result.success) {
         setData(result.data.data)
@@ -43,16 +61,26 @@ export function FeesListClient() {
     } finally {
       setLoading(false)
     }
+  }, [page, feeTypeFilter, yearFilter])
+
+  const fetchYears = useCallback(async () => {
+    try {
+      const result = await getFeeYears()
+      if (result.success) {
+        setAvailableYears(result.data)
+      }
+    } catch {
+      // silent — non-critical
+    }
   }, [])
 
   useEffect(() => {
-    fetchData(page)
-  }, [fetchData, page])
+    fetchData()
+  }, [fetchData])
 
-  function handlePageChange(newPage: number) {
-    setPage(newPage)
-    fetchData(newPage)
-  }
+  useEffect(() => {
+    fetchYears()
+  }, [fetchYears])
 
   function handleAddNew() {
     setEditTarget(null)
@@ -67,13 +95,36 @@ export function FeesListClient() {
   function handleFormSuccess() {
     setSheetOpen(false)
     setEditTarget(null)
-    fetchData(page)
+    fetchData()
+    fetchYears()
   }
+
+  const yearOptions = [
+    { value: 'all', label: 'Semua Tahun' },
+    ...availableYears.map((y) => ({ value: String(y), label: String(y) })),
+  ]
 
   return (
     <div className="space-y-4">
       {/* Toolbar */}
-      <div className="flex justify-end">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex gap-2">
+          <FilterSelect
+            options={feeTypeOptions}
+            paramKey="feeType"
+            placeholder="Semua Tipe"
+            className="w-[140px]"
+          />
+          {availableYears.length > 0 && (
+            <FilterSelect
+              options={yearOptions}
+              paramKey="year"
+              placeholder="Semua Tahun"
+              className="w-[140px]"
+            />
+          )}
+        </div>
+
         <Button onClick={handleAddNew}>
           <PlusIcon className="size-4 mr-2" />
           Tambah Tarif
@@ -91,7 +142,6 @@ export function FeesListClient() {
           total={total}
           page={page}
           perPage={perPage}
-          onPageChange={handlePageChange}
           onEdit={handleEdit}
         />
       )}

--- a/components/fees/fees-table.tsx
+++ b/components/fees/fees-table.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { UrlPagination } from '@/components/data-table/url-pagination'
 import type { FeeRow } from '@/lib/validations/fee'
 
 interface FeesTableProps {
@@ -17,7 +18,6 @@ interface FeesTableProps {
   total: number
   page: number
   perPage: number
-  onPageChange: (page: number) => void
   onEdit: (fee: FeeRow) => void
 }
 
@@ -45,10 +45,8 @@ export function FeesTable({
   total,
   page,
   perPage,
-  onPageChange,
   onEdit,
 }: FeesTableProps) {
-  const totalPages = Math.ceil(total / perPage)
 
   if (data.length === 0) {
     return (
@@ -101,32 +99,12 @@ export function FeesTable({
       </div>
 
       {/* Paginasi */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between text-sm text-muted-foreground">
-          <span>
-            Menampilkan {(page - 1) * perPage + 1}–{Math.min(page * perPage, total)} dari{' '}
-            {total} tarif
-          </span>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onPageChange(page - 1)}
-              disabled={page <= 1}
-            >
-              Sebelumnya
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onPageChange(page + 1)}
-              disabled={page >= totalPages}
-            >
-              Berikutnya
-            </Button>
-          </div>
-        </div>
-      )}
+      <UrlPagination
+        total={total}
+        page={page}
+        perPage={perPage}
+        itemLabel="tarif"
+      />
     </div>
   )
 }

--- a/components/institutes/institutes-list-client.tsx
+++ b/components/institutes/institutes-list-client.tsx
@@ -1,103 +1,79 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
-import { PlusIcon, SearchIcon } from 'lucide-react'
+import { useEffect, useCallback, useState } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { PlusIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { SearchInput } from '@/components/data-table/search-input'
+import { FilterSelect } from '@/components/data-table/filter-select'
 import { InstitutesTable } from './institutes-table'
 import { getInstitutes } from '@/actions/institute.actions'
 import type { InstituteWithParent } from '@/lib/validations/institute'
 
+const typeOptions = [
+  { value: 'all', label: 'Semua Tipe' },
+  { value: 'foundation', label: 'Yayasan' },
+  { value: 'school', label: 'Sekolah' },
+]
+
 export function InstitutesListClient() {
   const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const search = searchParams.get('search') ?? ''
+  const typeFilter = searchParams.get('type') ?? 'all'
+  const page = Number(searchParams.get('page') ?? '1')
+
   const [data, setData] = useState<InstituteWithParent[]>([])
   const [total, setTotal] = useState(0)
-  const [page, setPage] = useState(1)
-  const [search, setSearch] = useState('')
-  const [typeFilter, setTypeFilter] = useState<'all' | 'foundation' | 'school'>('all')
   const [loading, setLoading] = useState(true)
 
   const perPage = 10
 
-  const fetchData = useCallback(
-    async (currentPage: number, currentSearch: string, currentType: typeof typeFilter) => {
-      setLoading(true)
-      try {
-        const result = await getInstitutes({
-          page: currentPage,
-          perPage,
-          search: currentSearch || undefined,
-          type: currentType === 'all' ? undefined : currentType,
-        })
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const result = await getInstitutes({
+        page,
+        perPage,
+        search: search || undefined,
+        type: typeFilter !== 'all' ? (typeFilter as 'foundation' | 'school') : undefined,
+      })
 
-        if (result.success) {
-          setData(result.data.data)
-          setTotal(result.data.total)
-        } else {
-          toast.error(result.error)
-        }
-      } catch {
-        toast.error('Gagal memuat data institusi.')
-      } finally {
-        setLoading(false)
+      if (result.success) {
+        setData(result.data.data)
+        setTotal(result.data.total)
+      } else {
+        toast.error(result.error)
       }
-    },
-    [],
-  )
+    } catch {
+      toast.error('Gagal memuat data institusi.')
+    } finally {
+      setLoading(false)
+    }
+  }, [page, search, typeFilter])
 
-  // Debounce search
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      setPage(1)
-      fetchData(1, search, typeFilter)
-    }, 400)
-
-    return () => clearTimeout(timeout)
-  }, [search, typeFilter, fetchData])
-
-  function handlePageChange(newPage: number) {
-    setPage(newPage)
-    fetchData(newPage, search, typeFilter)
-  }
+    fetchData()
+  }, [fetchData])
 
   return (
     <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-1 gap-2 max-w-md">
-          <div className="relative flex-1">
-            <SearchIcon className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
-            <Input
-              placeholder="Cari nama, telepon, atau alamat..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-8"
-            />
-          </div>
-          <Select
-            value={typeFilter}
-            onValueChange={(val) =>
-              setTypeFilter(val as 'all' | 'foundation' | 'school')
-            }
-          >
-            <SelectTrigger className="w-36">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Semua Tipe</SelectItem>
-              <SelectItem value="foundation">Yayasan</SelectItem>
-              <SelectItem value="school">Sekolah</SelectItem>
-            </SelectContent>
-          </Select>
+        <div className="flex flex-1 gap-2 max-w-lg">
+          <SearchInput
+            placeholder="Cari nama, telepon, atau alamat..."
+            paramKey="search"
+            className="max-w-sm"
+          />
+          <FilterSelect
+            options={typeOptions}
+            paramKey="type"
+            placeholder="Semua Tipe"
+            className="w-36"
+          />
         </div>
 
         <Button onClick={() => router.push('/superadmin/institutes/new')}>
@@ -117,7 +93,6 @@ export function InstitutesListClient() {
           total={total}
           page={page}
           perPage={perPage}
-          onPageChange={handlePageChange}
         />
       )}
     </div>

--- a/components/institutes/institutes-table.tsx
+++ b/components/institutes/institutes-table.tsx
@@ -22,6 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { UrlPagination } from '@/components/data-table/url-pagination'
 import { deactivateInstitute } from '@/actions/institute.actions'
 import type { InstituteWithParent } from '@/lib/validations/institute'
 
@@ -30,7 +31,6 @@ interface InstitutesTableProps {
   total: number
   page: number
   perPage: number
-  onPageChange: (page: number) => void
 }
 
 export function InstitutesTable({
@@ -38,13 +38,10 @@ export function InstitutesTable({
   total,
   page,
   perPage,
-  onPageChange,
 }: InstitutesTableProps) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [deactivateTarget, setDeactivateTarget] = useState<InstituteWithParent | null>(null)
-
-  const totalPages = Math.ceil(total / perPage)
 
   const handleDeactivate = useCallback(() => {
     if (!deactivateTarget) return
@@ -147,32 +144,12 @@ export function InstitutesTable({
       </div>
 
       {/* Paginasi */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-4">
-          <p className="text-sm text-muted-foreground">
-            Menampilkan {(page - 1) * perPage + 1}–{Math.min(page * perPage, total)} dari{' '}
-            {total} institusi
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page <= 1 || isPending}
-              onClick={() => onPageChange(page - 1)}
-            >
-              Sebelumnya
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages || isPending}
-              onClick={() => onPageChange(page + 1)}
-            >
-              Berikutnya
-            </Button>
-          </div>
-        </div>
-      )}
+      <UrlPagination
+        total={total}
+        page={page}
+        perPage={perPage}
+        itemLabel="institusi"
+      />
 
       {/* Dialog konfirmasi deactivate */}
       <Dialog

--- a/components/staffs/staffs-list-client.tsx
+++ b/components/staffs/staffs-list-client.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { PlusIcon, SearchIcon } from 'lucide-react'
+import { useSearchParams } from 'next/navigation'
+import { PlusIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import {
   Sheet,
   SheetContent,
@@ -12,11 +12,13 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
+import { SearchInput } from '@/components/data-table/search-input'
+import { FilterSelect } from '@/components/data-table/filter-select'
 import { StaffsTable } from './staffs-table'
 import { StaffForm } from './staff-form'
 import { LinkUserDialog } from './link-user-dialog'
 import { getStaffs } from '@/actions/staff.actions'
-import type { StaffWithUser } from '@/lib/validations/staff'
+import type { StaffWithUser, StaffStatus, StaffDepartment } from '@/lib/validations/staff'
 
 interface StaffsListClientProps {
   subAppKey?: string
@@ -25,16 +27,38 @@ interface StaffsListClientProps {
   showInstitute?: boolean
 }
 
+const statusOptions = [
+  { value: 'all', label: 'Semua Status' },
+  { value: 'active', label: 'Aktif' },
+  { value: 'inactive', label: 'Tidak Aktif' },
+  { value: 'resigned', label: 'Keluar' },
+]
+
+const departmentOptions = [
+  { value: 'all', label: 'Semua Departemen' },
+  { value: 'academic', label: 'Akademik' },
+  { value: 'administration', label: 'Administrasi' },
+  { value: 'finance', label: 'Keuangan' },
+  { value: 'it', label: 'IT' },
+  { value: 'hr', label: 'SDM' },
+  { value: 'other', label: 'Lainnya' },
+]
+
 export function StaffsListClient({
   subAppKey,
   instituteId,
   isSuperadmin = false,
   showInstitute = false,
 }: StaffsListClientProps) {
+  const searchParams = useSearchParams()
+
+  const search = searchParams.get('search') ?? ''
+  const statusFilter = searchParams.get('status') ?? 'all'
+  const departmentFilter = searchParams.get('department') ?? 'all'
+  const page = Number(searchParams.get('page') ?? '1')
+
   const [data, setData] = useState<StaffWithUser[]>([])
   const [total, setTotal] = useState(0)
-  const [page, setPage] = useState(1)
-  const [search, setSearch] = useState('')
   const [loading, setLoading] = useState(true)
 
   // Sheet states
@@ -47,48 +71,36 @@ export function StaffsListClient({
 
   const perPage = 10
 
-  const fetchData = useCallback(
-    async (currentPage: number, currentSearch: string) => {
-      setLoading(true)
-      try {
-        const result = await getStaffs(
-          {
-            page: currentPage,
-            perPage,
-            search: currentSearch || undefined,
-          },
-          subAppKey,
-        )
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const result = await getStaffs(
+        {
+          page,
+          perPage,
+          search: search || undefined,
+          status: statusFilter !== 'all' ? (statusFilter as StaffStatus) : undefined,
+          department: departmentFilter !== 'all' ? (departmentFilter as StaffDepartment) : undefined,
+        },
+        subAppKey,
+      )
 
-        if (result.success) {
-          setData(result.data.data)
-          setTotal(result.data.total)
-        } else {
-          toast.error(result.error)
-        }
-      } catch {
-        toast.error('Gagal memuat data staf.')
-      } finally {
-        setLoading(false)
+      if (result.success) {
+        setData(result.data.data)
+        setTotal(result.data.total)
+      } else {
+        toast.error(result.error)
       }
-    },
-    [subAppKey],
-  )
+    } catch {
+      toast.error('Gagal memuat data staf.')
+    } finally {
+      setLoading(false)
+    }
+  }, [page, search, statusFilter, departmentFilter, subAppKey])
 
-  // Debounce search
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      setPage(1)
-      fetchData(1, search)
-    }, 400)
-
-    return () => clearTimeout(timeout)
-  }, [search, fetchData])
-
-  function handlePageChange(newPage: number) {
-    setPage(newPage)
-    fetchData(newPage, search)
-  }
+    fetchData()
+  }, [fetchData])
 
   function handleAddNew() {
     setEditTarget(null)
@@ -108,24 +120,34 @@ export function StaffsListClient({
   function handleFormSuccess() {
     setSheetOpen(false)
     setEditTarget(null)
-    fetchData(page, search)
+    fetchData()
   }
 
   function handleLinkSuccess() {
-    fetchData(page, search)
+    fetchData()
   }
 
   return (
     <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="relative flex-1 max-w-sm">
-          <SearchIcon className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
-          <Input
+        <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+          <SearchInput
             placeholder="Cari nama, no. staf, atau email..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-8"
+            paramKey="search"
+            className="max-w-sm"
+          />
+          <FilterSelect
+            options={statusOptions}
+            paramKey="status"
+            placeholder="Semua Status"
+            className="w-[160px]"
+          />
+          <FilterSelect
+            options={departmentOptions}
+            paramKey="department"
+            placeholder="Semua Departemen"
+            className="w-[175px]"
           />
         </div>
 
@@ -146,10 +168,9 @@ export function StaffsListClient({
           total={total}
           page={page}
           perPage={perPage}
-          onPageChange={handlePageChange}
           onEdit={handleEdit}
           onLinkUser={handleLinkUser}
-          onRefresh={() => fetchData(page, search)}
+          onRefresh={fetchData}
           subAppKey={subAppKey}
           showInstitute={showInstitute}
         />

--- a/components/staffs/staffs-table.tsx
+++ b/components/staffs/staffs-table.tsx
@@ -27,6 +27,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { UrlPagination } from '@/components/data-table/url-pagination'
 import { toggleStaffStatus, unlinkUserAccount } from '@/actions/staff.actions'
 import type { StaffWithUser } from '@/lib/validations/staff'
 
@@ -35,7 +36,6 @@ interface StaffsTableProps {
   total: number
   page: number
   perPage: number
-  onPageChange: (page: number) => void
   onEdit: (staff: StaffWithUser) => void
   onLinkUser: (staff: StaffWithUser) => void
   onRefresh: () => void
@@ -63,7 +63,6 @@ export function StaffsTable({
   total,
   page,
   perPage,
-  onPageChange,
   onEdit,
   onLinkUser,
   onRefresh,
@@ -73,8 +72,6 @@ export function StaffsTable({
   const [isPending, startTransition] = useTransition()
   const [toggleTarget, setToggleTarget] = useState<StaffWithUser | null>(null)
   const [unlinkTarget, setUnlinkTarget] = useState<StaffWithUser | null>(null)
-
-  const totalPages = Math.ceil(total / perPage)
 
   const handleToggleStatus = useCallback(() => {
     if (!toggleTarget) return
@@ -232,32 +229,12 @@ export function StaffsTable({
       </div>
 
       {/* Paginasi */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-4">
-          <p className="text-sm text-muted-foreground">
-            Menampilkan {(page - 1) * perPage + 1}–{Math.min(page * perPage, total)} dari{' '}
-            {total} staf
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page <= 1 || isPending}
-              onClick={() => onPageChange(page - 1)}
-            >
-              Sebelumnya
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages || isPending}
-              onClick={() => onPageChange(page + 1)}
-            >
-              Berikutnya
-            </Button>
-          </div>
-        </div>
-      )}
+      <UrlPagination
+        total={total}
+        page={page}
+        perPage={perPage}
+        itemLabel="staf"
+      />
 
       {/* Dialog konfirmasi toggle status */}
       <Dialog

--- a/components/students/students-list-client.tsx
+++ b/components/students/students-list-client.tsx
@@ -1,17 +1,10 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { PlusIcon, SearchIcon } from 'lucide-react'
+import { useSearchParams } from 'next/navigation'
+import { PlusIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import {
   Sheet,
   SheetContent,
@@ -19,6 +12,8 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
+import { SearchInput } from '@/components/data-table/search-input'
+import { FilterSelect } from '@/components/data-table/filter-select'
 import { StudentsTable } from './students-table'
 import { StudentForm } from './student-form'
 import { getStudents, getGenerationYears } from '@/actions/student.actions'
@@ -31,7 +26,7 @@ interface StudentsListClientProps {
   showInstitute?: boolean
 }
 
-const statusOptions: { value: StudentStatus | 'all'; label: string }[] = [
+const statusOptions = [
   { value: 'all', label: 'Semua Status' },
   { value: 'pending', label: 'Pending' },
   { value: 'active', label: 'Aktif' },
@@ -48,56 +43,49 @@ export function StudentsListClient({
   isSuperadmin = false,
   showInstitute = false,
 }: StudentsListClientProps) {
+  const searchParams = useSearchParams()
+
+  const search = searchParams.get('search') ?? ''
+  const statusFilter = searchParams.get('status') ?? 'all'
+  const yearFilter = searchParams.get('year') ?? 'all'
+  const page = Number(searchParams.get('page') ?? '1')
+
   const [data, setData] = useState<StudentRow[]>([])
   const [total, setTotal] = useState(0)
-  const [page, setPage] = useState(1)
-  const [search, setSearch] = useState('')
-  const [statusFilter, setStatusFilter] = useState<StudentStatus | 'all'>('all')
-  const [yearFilter, setYearFilter] = useState<string>('all')
-
-  const [availableYears, setAvailableYears] = useState<number[]>([])
   const [loading, setLoading] = useState(true)
+  const [availableYears, setAvailableYears] = useState<number[]>([])
 
   const [sheetOpen, setSheetOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<StudentRow | null>(null)
 
   const perPage = 10
 
-  const fetchData = useCallback(
-    async (
-      currentPage: number,
-      currentSearch: string,
-      currentStatus: StudentStatus | 'all',
-      currentYear: string,
-    ) => {
-      setLoading(true)
-      try {
-        const result = await getStudents(
-          {
-            page: currentPage,
-            perPage,
-            search: currentSearch || undefined,
-            status: currentStatus !== 'all' ? currentStatus : undefined,
-            generationYear:
-              currentYear !== 'all' ? Number(currentYear) : undefined,
-          },
-          subAppKey,
-        )
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const result = await getStudents(
+        {
+          page,
+          perPage,
+          search: search || undefined,
+          status: statusFilter !== 'all' ? (statusFilter as StudentStatus) : undefined,
+          generationYear: yearFilter !== 'all' ? Number(yearFilter) : undefined,
+        },
+        subAppKey,
+      )
 
-        if (result.success) {
-          setData(result.data.data)
-          setTotal(result.data.total)
-        } else {
-          toast.error(result.error)
-        }
-      } catch {
-        toast.error('Gagal memuat data siswa.')
-      } finally {
-        setLoading(false)
+      if (result.success) {
+        setData(result.data.data)
+        setTotal(result.data.total)
+      } else {
+        toast.error(result.error)
       }
-    },
-    [subAppKey],
-  )
+    } catch {
+      toast.error('Gagal memuat data siswa.')
+    } finally {
+      setLoading(false)
+    }
+  }, [page, search, statusFilter, yearFilter, subAppKey])
 
   const fetchYears = useCallback(async () => {
     try {
@@ -110,23 +98,13 @@ export function StudentsListClient({
     }
   }, [subAppKey])
 
-  // Initial load and debounced search
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      setPage(1)
-      fetchData(1, search, statusFilter, yearFilter)
-    }, 400)
-    return () => clearTimeout(timeout)
-  }, [search, statusFilter, yearFilter, fetchData])
+    fetchData()
+  }, [fetchData])
 
   useEffect(() => {
     fetchYears()
   }, [fetchYears])
-
-  function handlePageChange(newPage: number) {
-    setPage(newPage)
-    fetchData(newPage, search, statusFilter, yearFilter)
-  }
 
   function handleAddNew() {
     setEditTarget(null)
@@ -141,58 +119,38 @@ export function StudentsListClient({
   function handleFormSuccess() {
     setSheetOpen(false)
     setEditTarget(null)
-    fetchData(page, search, statusFilter, yearFilter)
+    fetchData()
     fetchYears()
   }
+
+  const yearOptions = [
+    { value: 'all', label: 'Semua Angkatan' },
+    ...availableYears.map((y) => ({ value: String(y), label: `Angkatan ${y}` })),
+  ]
 
   return (
     <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
-          <div className="relative flex-1 max-w-sm">
-            <SearchIcon className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
-            <Input
-              placeholder="Cari nama, NISN, atau no. siswa..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-8"
-            />
-          </div>
-
-          <Select
-            value={statusFilter}
-            onValueChange={(val) => setStatusFilter(val as StudentStatus | 'all')}
-          >
-            <SelectTrigger className="w-full sm:w-[160px]">
-              <SelectValue placeholder="Semua Status" />
-            </SelectTrigger>
-            <SelectContent>
-              {statusOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
+          <SearchInput
+            placeholder="Cari nama, NISN, atau no. siswa..."
+            paramKey="search"
+            className="max-w-sm"
+          />
+          <FilterSelect
+            options={statusOptions}
+            paramKey="status"
+            placeholder="Semua Status"
+            className="w-[160px]"
+          />
           {availableYears.length > 0 && (
-            <Select
-              value={yearFilter}
-              onValueChange={(val) => setYearFilter(val ?? 'all')}
-            >
-              <SelectTrigger className="w-full sm:w-[140px]">
-                <SelectValue placeholder="Semua Angkatan" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Semua Angkatan</SelectItem>
-                {availableYears.map((year) => (
-                  <SelectItem key={year} value={String(year)}>
-                    Angkatan {year}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <FilterSelect
+              options={yearOptions}
+              paramKey="year"
+              placeholder="Semua Angkatan"
+              className="w-[155px]"
+            />
           )}
         </div>
 
@@ -213,9 +171,8 @@ export function StudentsListClient({
           total={total}
           page={page}
           perPage={perPage}
-          onPageChange={handlePageChange}
           onEdit={handleEdit}
-          onRefresh={() => fetchData(page, search, statusFilter, yearFilter)}
+          onRefresh={fetchData}
           subAppKey={subAppKey}
           showInstitute={showInstitute}
         />

--- a/components/students/students-table.tsx
+++ b/components/students/students-table.tsx
@@ -28,6 +28,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { UrlPagination } from '@/components/data-table/url-pagination'
 import {
   activateStudent,
   deactivateStudent,
@@ -40,7 +41,6 @@ interface StudentsTableProps {
   total: number
   page: number
   perPage: number
-  onPageChange: (page: number) => void
   onEdit: (student: StudentRow) => void
   onRefresh: () => void
   subAppKey?: string
@@ -70,7 +70,6 @@ export function StudentsTable({
   total,
   page,
   perPage,
-  onPageChange,
   onEdit,
   onRefresh,
   subAppKey,
@@ -78,8 +77,6 @@ export function StudentsTable({
 }: StudentsTableProps) {
   const [isPending, startTransition] = useTransition()
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null)
-
-  const totalPages = Math.ceil(total / perPage)
 
   const handleConfirm = useCallback(() => {
     if (!confirmAction) return
@@ -300,32 +297,12 @@ export function StudentsTable({
       </div>
 
       {/* Paginasi */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-4">
-          <p className="text-sm text-muted-foreground">
-            Menampilkan {(page - 1) * perPage + 1}–{Math.min(page * perPage, total)} dari{' '}
-            {total} siswa
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page <= 1 || isPending}
-              onClick={() => onPageChange(page - 1)}
-            >
-              Sebelumnya
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages || isPending}
-              onClick={() => onPageChange(page + 1)}
-            >
-              Berikutnya
-            </Button>
-          </div>
-        </div>
-      )}
+      <UrlPagination
+        total={total}
+        page={page}
+        perPage={perPage}
+        itemLabel="siswa"
+      />
 
       {/* Dialog konfirmasi aksi status */}
       <Dialog

--- a/components/transfers/transfers-list-client.tsx
+++ b/components/transfers/transfers-list-client.tsx
@@ -1,16 +1,11 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { PlusIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { FilterSelect } from '@/components/data-table/filter-select'
 import { TransfersTable } from './transfers-table'
 import { CreateTransferSheet } from './create-transfer-sheet'
 import { getTransfers } from '@/actions/transfer.actions'
@@ -23,7 +18,7 @@ interface TransfersListClientProps {
   basePath: string
 }
 
-const statusOptions: { value: TransferStatus | 'all'; label: string }[] = [
+const statusOptions = [
   { value: 'all', label: 'Semua Status' },
   { value: 'pending', label: 'Menunggu' },
   { value: 'approved', label: 'Disetujui' },
@@ -31,13 +26,13 @@ const statusOptions: { value: TransferStatus | 'all'; label: string }[] = [
   { value: 'cancelled', label: 'Dibatalkan' },
 ]
 
-const directionOptions: { value: 'all' | 'outgoing' | 'incoming'; label: string }[] = [
+const directionOptions = [
   { value: 'all', label: 'Semua Arah' },
   { value: 'outgoing', label: 'Keluar' },
   { value: 'incoming', label: 'Masuk' },
 ]
 
-const methodOptions: { value: TransferMethod | 'all'; label: string }[] = [
+const methodOptions = [
   { value: 'all', label: 'Semua Metode' },
   { value: 'cash', label: 'Tunai' },
   { value: 'bank_transfer', label: 'Transfer Bank' },
@@ -50,65 +45,54 @@ export function TransfersListClient({
   scopedInstituteId,
   basePath,
 }: TransfersListClientProps) {
+  const searchParams = useSearchParams()
+
+  const statusFilter = searchParams.get('status') ?? 'all'
+  const directionFilter = searchParams.get('direction') ?? 'all'
+  const methodFilter = searchParams.get('method') ?? 'all'
+  const page = Number(searchParams.get('page') ?? '1')
+
   const [data, setData] = useState<TransferRow[]>([])
   const [total, setTotal] = useState(0)
-  const [page, setPage] = useState(1)
-  const [statusFilter, setStatusFilter] = useState<TransferStatus | 'all'>('all')
-  const [directionFilter, setDirectionFilter] = useState<'all' | 'outgoing' | 'incoming'>('all')
-  const [methodFilter, setMethodFilter] = useState<TransferMethod | 'all'>('all')
   const [loading, setLoading] = useState(true)
   const [sheetOpen, setSheetOpen] = useState(false)
 
   const perPage = 10
 
-  const fetchData = useCallback(
-    async (
-      currentPage: number,
-      currentStatus: TransferStatus | 'all',
-      currentDirection: 'all' | 'outgoing' | 'incoming',
-      currentMethod: TransferMethod | 'all',
-    ) => {
-      setLoading(true)
-      try {
-        const result = await getTransfers(
-          {
-            page: currentPage,
-            perPage,
-            status: currentStatus !== 'all' ? currentStatus : undefined,
-            direction: currentDirection !== 'all' ? currentDirection : undefined,
-            transferMethod: currentMethod !== 'all' ? currentMethod : undefined,
-          },
-          subAppKey,
-        )
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const result = await getTransfers(
+        {
+          page,
+          perPage,
+          status: statusFilter !== 'all' ? (statusFilter as TransferStatus) : undefined,
+          direction: directionFilter !== 'all' ? (directionFilter as 'outgoing' | 'incoming') : undefined,
+          transferMethod: methodFilter !== 'all' ? (methodFilter as TransferMethod) : undefined,
+        },
+        subAppKey,
+      )
 
-        if (result.success) {
-          setData(result.data.data)
-          setTotal(result.data.total)
-        } else {
-          toast.error(result.error)
-        }
-      } catch {
-        toast.error('Gagal memuat data transfer.')
-      } finally {
-        setLoading(false)
+      if (result.success) {
+        setData(result.data.data)
+        setTotal(result.data.total)
+      } else {
+        toast.error(result.error)
       }
-    },
-    [subAppKey],
-  )
+    } catch {
+      toast.error('Gagal memuat data transfer.')
+    } finally {
+      setLoading(false)
+    }
+  }, [page, statusFilter, directionFilter, methodFilter, subAppKey])
 
   useEffect(() => {
-    setPage(1)
-    fetchData(1, statusFilter, directionFilter, methodFilter)
-  }, [statusFilter, directionFilter, methodFilter, fetchData])
-
-  function handlePageChange(newPage: number) {
-    setPage(newPage)
-    fetchData(newPage, statusFilter, directionFilter, methodFilter)
-  }
+    fetchData()
+  }, [fetchData])
 
   function handleFormSuccess() {
     setSheetOpen(false)
-    fetchData(page, statusFilter, directionFilter, methodFilter)
+    fetchData()
   }
 
   return (
@@ -116,57 +100,26 @@ export function TransfersListClient({
       {/* Toolbar */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
-          <Select
-            value={statusFilter}
-            onValueChange={(val) => setStatusFilter(val as TransferStatus | 'all')}
-          >
-            <SelectTrigger className="w-full sm:w-[160px]">
-              <SelectValue placeholder="Semua Status" />
-            </SelectTrigger>
-            <SelectContent>
-              {statusOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
+          <FilterSelect
+            options={statusOptions}
+            paramKey="status"
+            placeholder="Semua Status"
+            className="w-[160px]"
+          />
           {scopedInstituteId && (
-            <Select
-              value={directionFilter}
-              onValueChange={(val) =>
-                setDirectionFilter(val as 'all' | 'outgoing' | 'incoming')
-              }
-            >
-              <SelectTrigger className="w-full sm:w-[150px]">
-                <SelectValue placeholder="Semua Arah" />
-              </SelectTrigger>
-              <SelectContent>
-                {directionOptions.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <FilterSelect
+              options={directionOptions}
+              paramKey="direction"
+              placeholder="Semua Arah"
+              className="w-[150px]"
+            />
           )}
-
-          <Select
-            value={methodFilter}
-            onValueChange={(val) => setMethodFilter(val as TransferMethod | 'all')}
-          >
-            <SelectTrigger className="w-full sm:w-[160px]">
-              <SelectValue placeholder="Semua Metode" />
-            </SelectTrigger>
-            <SelectContent>
-              {methodOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <FilterSelect
+            options={methodOptions}
+            paramKey="method"
+            placeholder="Semua Metode"
+            className="w-[160px]"
+          />
         </div>
 
         <Button onClick={() => setSheetOpen(true)}>
@@ -186,8 +139,7 @@ export function TransfersListClient({
           total={total}
           page={page}
           perPage={perPage}
-          onPageChange={handlePageChange}
-          onRefresh={() => fetchData(page, statusFilter, directionFilter, methodFilter)}
+          onRefresh={fetchData}
           subAppKey={subAppKey}
           subappType={subappType}
           scopedInstituteId={scopedInstituteId}

--- a/components/transfers/transfers-table.tsx
+++ b/components/transfers/transfers-table.tsx
@@ -22,6 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { UrlPagination } from '@/components/data-table/url-pagination'
 import { cancelTransfer } from '@/actions/transfer.actions'
 import { statusConfig, transferMethodLabels, formatRupiah, formatDateWITA } from './transfer-utils'
 import type { TransferRow, TransferStatus } from '@/lib/validations/transfer'
@@ -32,7 +33,6 @@ interface TransfersTableProps {
   total: number
   page: number
   perPage: number
-  onPageChange: (page: number) => void
   onRefresh: () => void
   subAppKey?: string
   subappType?: string
@@ -45,7 +45,6 @@ export function TransfersTable({
   total,
   page,
   perPage,
-  onPageChange,
   onRefresh,
   subAppKey,
   subappType,
@@ -55,7 +54,6 @@ export function TransfersTable({
   const [cancelTarget, setCancelTarget] = useState<TransferRow | null>(null)
   const [approveTarget, setApproveTarget] = useState<TransferRow | null>(null)
 
-  const totalPages = Math.ceil(total / perPage)
   const canApproveCancel = subappType !== 'school'
 
   const handleCancel = useCallback(() => {
@@ -171,32 +169,12 @@ export function TransfersTable({
       </div>
 
       {/* Paginasi */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-4">
-          <p className="text-sm text-muted-foreground">
-            Menampilkan {(page - 1) * perPage + 1}–{Math.min(page * perPage, total)} dari {total}{' '}
-            transfer
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page <= 1 || isPending}
-              onClick={() => onPageChange(page - 1)}
-            >
-              Sebelumnya
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages || isPending}
-              onClick={() => onPageChange(page + 1)}
-            >
-              Berikutnya
-            </Button>
-          </div>
-        </div>
-      )}
+      <UrlPagination
+        total={total}
+        page={page}
+        perPage={perPage}
+        itemLabel="transfer"
+      />
 
       {/* Dialog konfirmasi batalkan */}
       <Dialog open={!!cancelTarget} onOpenChange={(open) => !open && setCancelTarget(null)}>

--- a/lib/validations/fee.ts
+++ b/lib/validations/fee.ts
@@ -32,6 +32,8 @@ export const updateFeeSchema = z.object({
 export const getFeesSchema = z.object({
   page: z.number().int().min(1).default(1),
   perPage: z.number().int().min(1).max(100).default(10),
+  feeType: z.enum(feeTypeValues).optional(),
+  year: z.number().int().optional(),
 })
 
 export type CreateFeeInput = z.infer<typeof createFeeSchema>

--- a/lib/validations/staff.ts
+++ b/lib/validations/staff.ts
@@ -73,10 +73,18 @@ export const updateStaffSchema = z.object({
   status: z.enum(['active', 'inactive', 'resigned']),
 })
 
+export const staffStatusValues = ['active', 'inactive', 'resigned'] as const
+export type StaffStatus = (typeof staffStatusValues)[number]
+
+export const staffDepartmentValues = ['academic', 'administration', 'finance', 'it', 'hr', 'other'] as const
+export type StaffDepartment = (typeof staffDepartmentValues)[number]
+
 export const getStaffsSchema = z.object({
   page: z.number().int().min(1).default(1),
   perPage: z.number().int().min(1).max(100).default(10),
   search: z.string().optional(),
+  status: z.enum(staffStatusValues).optional(),
+  department: z.enum(staffDepartmentValues).optional(),
   instituteId: z.string().uuid().optional(),
 })
 


### PR DESCRIPTION
## Terkait Issue
Closes #19

## Ringkasan Perubahan

- Buat 4 komponen reusable di `components/data-table/`:
  - `SearchInput` — input search dengan debounce 300ms, update URL search params
  - `FilterSelect` — dropdown filter, update URL search params
  - `UrlPagination` — paginasi berbasis URL params
  - `DataTable` — tabel reusable generik dengan kolom konfigurabel
- Semua list view kini menggunakan URL search params → state bisa di-bookmark dan dipertahankan saat refresh
- Update semua list client (institutes, staffs, students, fees, fee-payments, transfers) untuk membaca filter dari URL
- Update semua table component untuk menggunakan `UrlPagination` (hapus callback `onPageChange`)
- Tambah filter baru: status & departemen di staf, tipe biaya & tahun di fees, tahun tarif di pembayaran SPP
- Update schema validasi: `getStaffsSchema` (+ status, department), `getFeesSchema` (+ feeType, year)
- Tambah `getFeeYears()` di `fee.actions.ts` untuk mendukung filter tahun biaya
- Tambah `Suspense` boundary di semua halaman yang menggunakan `useSearchParams`

## Hasil Test Plan

- TypeScript check: `pnpm tsc --noEmit` → Exit: 0 (tidak ada error)
- Tidak ada `any` di TypeScript
- Semua Server Action dilindungi `requireRole()` / `requireSubappAccess()`
- Error message dalam Bahasa Indonesia

## Checklist
- [x] `components/data-table/data-table.tsx` — tabel reusable dengan props: data, columns, pagination
- [x] `components/data-table/search-input.tsx` — input search dengan debounce 300ms, update URL search params
- [x] `components/data-table/filter-select.tsx` — dropdown filter, update URL search params
- [x] Paginasi server-side: default 10 item, via `?page=&limit=`
- [x] Update semua Server Actions list untuk menerima parameter filter dan pagination
- [x] Filter + search + paginasi bekerja bersamaan; refresh halaman mempertahankan filter