### PR TITLE
fix: SPP per semester + QA data isolation & fee type fixes

### DIFF
--- a/actions/fee-payment-export.actions.ts
+++ b/actions/fee-payment-export.actions.ts
@@ -20,6 +20,7 @@ export type ExportFeePaymentRow = {
   nisn: string
   feeType: string
   feeYear: number
+  feeSemester: number
   feeAmount: string
   amountPaid: string
   paymentMethod: string
@@ -120,6 +121,7 @@ export async function getFeePaymentsForExport(
         nisn: students.nisn,
         feeType: fees.feeType,
         feeYear: fees.year,
+        feeSemester: fees.semester,
         feeAmount: fees.amount,
         amountPaid: feePayments.amountPaid,
         paymentMethod: feePayments.paymentMethod,
@@ -142,6 +144,7 @@ export async function getFeePaymentsForExport(
       nisn: row.nisn,
       feeType: row.feeType,
       feeYear: row.feeYear,
+      feeSemester: row.feeSemester,
       feeAmount: row.feeAmount,
       amountPaid: row.amountPaid,
       paymentMethod: row.paymentMethod,

--- a/actions/fee-payment.actions.ts
+++ b/actions/fee-payment.actions.ts
@@ -100,6 +100,7 @@ export async function getFeePayments(
         feeId: feePayments.feeId,
         feeType: fees.feeType,
         feeYear: fees.year,
+        feeSemester: fees.semester,
         feeAmount: fees.amount,
         amountPaid: feePayments.amountPaid,
         paymentMethod: feePayments.paymentMethod,
@@ -131,6 +132,7 @@ export async function getFeePayments(
       ...row,
       feeType: row.feeType,
       feeYear: row.feeYear,
+      feeSemester: row.feeSemester,
       receipt: row.receipt ?? null,
       receiptFile: row.receiptFile ?? null,
     }))
@@ -185,6 +187,7 @@ export async function getFeePaymentsByStudent(
         feeId: feePayments.feeId,
         feeType: fees.feeType,
         feeYear: fees.year,
+        feeSemester: fees.semester,
         feeAmount: fees.amount,
         amountPaid: feePayments.amountPaid,
         paymentMethod: feePayments.paymentMethod,
@@ -205,6 +208,7 @@ export async function getFeePaymentsByStudent(
       ...row,
       feeType: row.feeType,
       feeYear: row.feeYear,
+      feeSemester: row.feeSemester,
       receipt: row.receipt ?? null,
       receiptFile: row.receiptFile ?? null,
     }))
@@ -426,6 +430,7 @@ async function sendPaymentConfirmedNotification(params: {
         studentInstituteId: students.instituteId,
         feeType: fees.feeType,
         feeYear: fees.year,
+        feeSemester: fees.semester,
       })
       .from(feePayments)
       .innerJoin(students, eq(feePayments.studentId, students.id))
@@ -464,6 +469,7 @@ async function sendPaymentConfirmedNotification(params: {
           studentNumber: detail.studentNumber,
           feeType: detail.feeType,
           feeYear: detail.feeYear,
+          feeSemester: detail.feeSemester,
           amountPaid: detail.amountPaid,
           paymentMethod: detail.paymentMethod,
           confirmedAt: new Date(),

--- a/actions/fee.actions.ts
+++ b/actions/fee.actions.ts
@@ -35,13 +35,14 @@ export async function getFees(
     perPage: input.perPage ?? 10,
     feeType: input.feeType,
     year: input.year,
+    semester: input.semester,
   })
 
   if (!parsed.success) {
     return { success: false, error: 'Parameter tidak valid.' }
   }
 
-  const { page, perPage, feeType, year } = parsed.data
+  const { page, perPage, feeType, year, semester } = parsed.data
   const offset = (page - 1) * perPage
 
   try {
@@ -55,6 +56,10 @@ export async function getFees(
       conditions.push(eq(fees.year, year))
     }
 
+    if (semester) {
+      conditions.push(eq(fees.semester, semester))
+    }
+
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined
 
     const rows = await db
@@ -62,6 +67,7 @@ export async function getFees(
         id: fees.id,
         feeType: fees.feeType,
         year: fees.year,
+        semester: fees.semester,
         amount: fees.amount,
         paymentCount: sql<number>`cast(count(${feePayments.id}) as int)`,
         createdAt: fees.createdAt,
@@ -71,7 +77,7 @@ export async function getFees(
       .leftJoin(feePayments, eq(feePayments.feeId, fees.id))
       .where(whereClause)
       .groupBy(fees.id)
-      .orderBy(desc(fees.year), fees.feeType)
+      .orderBy(desc(fees.year), fees.semester, fees.feeType)
       .limit(perPage)
       .offset(offset)
 
@@ -82,6 +88,7 @@ export async function getFees(
       id: row.id,
       feeType: row.feeType as FeeRow['feeType'],
       year: row.year,
+      semester: row.semester,
       amount: row.amount,
       paymentCount: row.paymentCount ?? 0,
       createdAt: row.createdAt,
@@ -114,7 +121,7 @@ export async function getFeeYears(): Promise<ActionResult<number[]>> {
 
 /**
  * Membuat tarif biaya baru.
- * Validasi: tidak ada duplikat kombinasi feeType + year.
+ * Validasi: tidak ada duplikat kombinasi feeType + year + semester.
  * Hanya superadmin yang dapat mengakses.
  */
 export async function createFee(input: CreateFeeInput): Promise<ActionResult<{ id: string }>> {
@@ -126,7 +133,7 @@ export async function createFee(input: CreateFeeInput): Promise<ActionResult<{ i
     return { success: false, error: firstError?.message ?? 'Data tidak valid.' }
   }
 
-  const { feeType, year, amount } = parsed.data
+  const { feeType, year, semester, amount } = parsed.data
 
   // Validasi Decimal.js
   let decimalAmount: string
@@ -141,23 +148,24 @@ export async function createFee(input: CreateFeeInput): Promise<ActionResult<{ i
   }
 
   try {
-    // Validasi: tidak ada duplikat tipe + tahun
+    // Validasi: tidak ada duplikat tipe + tahun + semester
     const existing = await db
       .select({ id: fees.id })
       .from(fees)
-      .where(and(eq(fees.feeType, feeType), eq(fees.year, year)))
+      .where(and(eq(fees.feeType, feeType), eq(fees.year, year), eq(fees.semester, semester)))
       .limit(1)
 
     if (existing.length > 0) {
+      const semesterLabel = semester === 1 ? 'Ganjil' : 'Genap'
       return {
         success: false,
-        error: `Tarif ${feeType.toUpperCase()} untuk tahun ${year} sudah ada. Tidak boleh duplikat.`,
+        error: `Tarif ${feeType.toUpperCase()} Semester ${semesterLabel} tahun ${year} sudah ada.`,
       }
     }
 
     const [newFee] = await db
       .insert(fees)
-      .values({ feeType, year, amount: decimalAmount })
+      .values({ feeType, year, semester, amount: decimalAmount })
       .returning({ id: fees.id })
 
     if (!newFee) {
@@ -174,7 +182,7 @@ export async function createFee(input: CreateFeeInput): Promise<ActionResult<{ i
 /**
  * Memperbarui tarif biaya.
  * Validasi: tidak ada pembayaran yang mengacu ke fee ini jika jumlah diubah.
- * Validasi: tidak ada duplikat tipe + tahun (kecuali record ini sendiri).
+ * Validasi: tidak ada duplikat tipe + tahun + semester (kecuali record ini sendiri).
  * Hanya superadmin yang dapat mengakses.
  */
 export async function updateFee(
@@ -193,7 +201,7 @@ export async function updateFee(
     return { success: false, error: firstError?.message ?? 'Data tidak valid.' }
   }
 
-  const { feeType, year, amount } = parsed.data
+  const { feeType, year, semester, amount } = parsed.data
 
   // Validasi Decimal.js
   let decimalAmount: string
@@ -210,7 +218,7 @@ export async function updateFee(
   try {
     // Pastikan fee ada
     const existing = await db
-      .select({ id: fees.id, amount: fees.amount, feeType: fees.feeType, year: fees.year })
+      .select({ id: fees.id, amount: fees.amount, feeType: fees.feeType, year: fees.year, semester: fees.semester })
       .from(fees)
       .where(eq(fees.id, id))
       .limit(1)
@@ -237,25 +245,26 @@ export async function updateFee(
       }
     }
 
-    // Validasi: tidak ada duplikat tipe + tahun kecuali record sendiri
-    if (feeType !== currentFee.feeType || year !== currentFee.year) {
+    // Validasi: tidak ada duplikat tipe + tahun + semester kecuali record sendiri
+    if (feeType !== currentFee.feeType || year !== currentFee.year || semester !== currentFee.semester) {
       const duplicate = await db
         .select({ id: fees.id })
         .from(fees)
-        .where(and(eq(fees.feeType, feeType), eq(fees.year, year)))
+        .where(and(eq(fees.feeType, feeType), eq(fees.year, year), eq(fees.semester, semester)))
         .limit(1)
 
       if (duplicate.length > 0) {
+        const semesterLabel = semester === 1 ? 'Ganjil' : 'Genap'
         return {
           success: false,
-          error: `Tarif ${feeType.toUpperCase()} untuk tahun ${year} sudah ada. Tidak boleh duplikat.`,
+          error: `Tarif ${feeType.toUpperCase()} Semester ${semesterLabel} tahun ${year} sudah ada.`,
         }
       }
     }
 
     await db
       .update(fees)
-      .set({ feeType, year, amount: decimalAmount, updatedAt: new Date() })
+      .set({ feeType, year, semester, amount: decimalAmount, updatedAt: new Date() })
       .where(eq(fees.id, id))
 
     revalidateFeePaths()
@@ -271,7 +280,7 @@ export async function updateFee(
  */
 export async function getFeesForPayment(
   subAppKey?: string,
-): Promise<ActionResult<{ id: string; feeType: string; year: number; amount: string }[]>> {
+): Promise<ActionResult<{ id: string; feeType: string; year: number; semester: number; amount: string }[]>> {
   if (subAppKey) {
     await requireSubappAccess(subAppKey)
   } else {
@@ -284,10 +293,11 @@ export async function getFeesForPayment(
         id: fees.id,
         feeType: fees.feeType,
         year: fees.year,
+        semester: fees.semester,
         amount: fees.amount,
       })
       .from(fees)
-      .orderBy(fees.year, fees.feeType)
+      .orderBy(fees.year, fees.semester, fees.feeType)
 
     return { success: true, data: rows }
   } catch {

--- a/actions/staff.actions.ts
+++ b/actions/staff.actions.ts
@@ -150,8 +150,11 @@ export async function getStaffById(
   id: string,
   subAppKey?: string,
 ): Promise<ActionResult<StaffWithUser>> {
+  let scopedInstituteId: string | undefined
+
   if (subAppKey) {
-    await requireSubappAccess(subAppKey)
+    const { subapp } = await requireSubappAccess(subAppKey)
+    scopedInstituteId = subapp.instituteId ?? undefined
   } else {
     await requireRole(['superadmin'])
   }
@@ -161,6 +164,10 @@ export async function getStaffById(
   }
 
   try {
+    const whereClause = scopedInstituteId
+      ? and(eq(staffs.id, id), eq(staffs.instituteId, scopedInstituteId))
+      : eq(staffs.id, id)
+
     const rows = await db
       .select({
         id: staffs.id,
@@ -186,7 +193,7 @@ export async function getStaffById(
       .from(staffs)
       .innerJoin(institutes, eq(staffs.instituteId, institutes.id))
       .leftJoin(users, eq(staffs.userId, users.id))
-      .where(eq(staffs.id, id))
+      .where(whereClause)
       .limit(1)
 
     const row = rows[0]
@@ -321,8 +328,11 @@ export async function updateStaff(
   input: UpdateStaffInput,
   subAppKey?: string,
 ): Promise<ActionResult<{ id: string }>> {
+  let scopedInstituteIdForUpdate: string | undefined
+
   if (subAppKey) {
-    await requireSubappAccess(subAppKey)
+    const { subapp } = await requireSubappAccess(subAppKey)
+    scopedInstituteIdForUpdate = subapp.instituteId ?? undefined
   } else {
     await requireRole(['superadmin'])
   }
@@ -341,11 +351,15 @@ export async function updateStaff(
     parsed.data
 
   try {
-    // Pastikan staf ada
+    // Pastikan staf ada dan milik institusi yang sama
+    const existingWhereClause = scopedInstituteIdForUpdate
+      ? and(eq(staffs.id, id), eq(staffs.instituteId, scopedInstituteIdForUpdate))
+      : eq(staffs.id, id)
+
     const existing = await db
       .select({ id: staffs.id, instituteId: staffs.instituteId })
       .from(staffs)
-      .where(eq(staffs.id, id))
+      .where(existingWhereClause)
       .limit(1)
 
     if (!existing[0]) {

--- a/actions/student.actions.ts
+++ b/actions/student.actions.ts
@@ -148,11 +148,14 @@ export async function getStudentById(
   id: string,
   subAppKey?: string,
 ): Promise<ActionResult<StudentRow>> {
+  let scopedInstituteId: string | undefined
+
   if (subAppKey) {
     const { subapp } = await requireSubappAccess(subAppKey)
     if (subapp.type !== 'school') {
       return { success: false, error: 'Akses ditolak.' }
     }
+    scopedInstituteId = subapp.instituteId ?? undefined
   } else {
     await requireRole(['superadmin'])
   }
@@ -162,6 +165,10 @@ export async function getStudentById(
   }
 
   try {
+    const whereClause = scopedInstituteId
+      ? and(eq(students.id, id), eq(students.instituteId, scopedInstituteId))
+      : eq(students.id, id)
+
     const rows = await db
       .select({
         id: students.id,
@@ -184,7 +191,7 @@ export async function getStudentById(
       })
       .from(students)
       .innerJoin(institutes, eq(students.instituteId, institutes.id))
-      .where(eq(students.id, id))
+      .where(whereClause)
       .limit(1)
 
     const row = rows[0]
@@ -351,11 +358,14 @@ export async function updateStudent(
   input: UpdateStudentInput,
   subAppKey?: string,
 ): Promise<ActionResult<{ id: string }>> {
+  let scopedInstituteIdForUpdate: string | undefined
+
   if (subAppKey) {
     const { subapp } = await requireSubappAccess(subAppKey)
     if (subapp.type !== 'school') {
       return { success: false, error: 'Akses ditolak.' }
     }
+    scopedInstituteIdForUpdate = subapp.instituteId ?? undefined
   } else {
     await requireRole(['superadmin'])
   }
@@ -385,11 +395,15 @@ export async function updateStudent(
   } = parsed.data
 
   try {
-    // Pastikan siswa ada
+    // Pastikan siswa ada dan milik institusi yang sama
+    const existingWhereClause = scopedInstituteIdForUpdate
+      ? and(eq(students.id, id), eq(students.instituteId, scopedInstituteIdForUpdate))
+      : eq(students.id, id)
+
     const existing = await db
       .select({ id: students.id })
       .from(students)
-      .where(eq(students.id, id))
+      .where(existingWhereClause)
       .limit(1)
 
     if (!existing[0]) {

--- a/components/fee-payments/fee-payment-form.tsx
+++ b/components/fee-payments/fee-payment-form.tsx
@@ -42,6 +42,7 @@ interface FeeOption {
   id: string
   feeType: string
   year: number
+  semester: number
   amount: string
 }
 
@@ -285,7 +286,7 @@ export function FeePaymentForm({ onSuccess, onCancel, subAppKey }: FeePaymentFor
                   ) : (
                     feeOptions.map((fee) => (
                       <SelectItem key={fee.id} value={fee.id}>
-                        {fee.feeType.toUpperCase()} {fee.year} — Rp{' '}
+                        {fee.feeType.toUpperCase()} {fee.year} Sem {fee.semester === 1 ? 'Ganjil' : 'Genap'} — Rp{' '}
                         {Number(fee.amount).toLocaleString('id-ID')}
                       </SelectItem>
                     ))

--- a/components/fee-payments/fee-payments-table.tsx
+++ b/components/fee-payments/fee-payments-table.tsx
@@ -145,7 +145,7 @@ export function FeePaymentsTable({
                     <TableCell>
                       <div>
                         <p className="text-sm font-medium">
-                          {feeTypeLabels[payment.feeType] ?? payment.feeType} {payment.feeYear}
+                          {feeTypeLabels[payment.feeType] ?? payment.feeType} {payment.feeYear} Sem {payment.feeSemester === 1 ? 'Ganjil' : 'Genap'}
                         </p>
                         <p className="text-xs text-muted-foreground">
                           Tarif: {formatRupiah(payment.feeAmount)}

--- a/components/fee-payments/student-payment-history.tsx
+++ b/components/fee-payments/student-payment-history.tsx
@@ -127,7 +127,7 @@ export function StudentPaymentHistory({ studentId, subAppKey }: StudentPaymentHi
               <TableRow key={payment.id}>
                 <TableCell>
                   <p className="text-sm font-medium">
-                    {feeTypeLabels[payment.feeType] ?? payment.feeType} {payment.feeYear}
+                    {feeTypeLabels[payment.feeType] ?? payment.feeType} {payment.feeYear} Sem {payment.feeSemester === 1 ? 'Ganjil' : 'Genap'}
                   </p>
                   <p className="text-xs text-muted-foreground">
                     Tarif: {formatRupiah(payment.feeAmount)}

--- a/components/fees/fee-form.tsx
+++ b/components/fees/fee-form.tsx
@@ -66,6 +66,7 @@ export function FeeForm({ mode, defaultValues, onSuccess, onCancel }: FeeFormPro
     defaultValues: {
       feeType: defaultValues?.feeType ?? 'spp',
       year: defaultValues?.year ?? currentYear,
+      semester: defaultValues?.semester ?? 1,
       amount: defaultAmount,
     },
   })
@@ -142,6 +143,33 @@ export function FeeForm({ mode, defaultValues, onSuccess, onCancel }: FeeFormPro
                       {year}
                     </SelectItem>
                   ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Semester */}
+        <FormField
+          control={form.control}
+          name="semester"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Semester</FormLabel>
+              <Select
+                onValueChange={(val) => field.onChange(Number(val))}
+                defaultValue={String(field.value)}
+                disabled={isSubmitting}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih semester" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="1">Semester 1 (Ganjil)</SelectItem>
+                  <SelectItem value="2">Semester 2 (Genap)</SelectItem>
                 </SelectContent>
               </Select>
               <FormMessage />

--- a/components/fees/fee-form.tsx
+++ b/components/fees/fee-form.tsx
@@ -38,7 +38,13 @@ interface FeeFormProps {
 }
 
 const feeTypeLabels: Record<string, string> = {
+  registration: 'Pendaftaran',
   spp: 'SPP',
+  building: 'Gedung',
+  uniform: 'Seragam',
+  book: 'Buku',
+  activity: 'Kegiatan',
+  other: 'Lainnya',
 }
 
 const currentYear = new Date().getFullYear()
@@ -112,7 +118,9 @@ export function FeeForm({ mode, defaultValues, onSuccess, onCancel }: FeeFormPro
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  <SelectItem value="spp">{feeTypeLabels['spp']}</SelectItem>
+                  {Object.entries(feeTypeLabels).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>{label}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               <FormMessage />

--- a/components/fees/fees-list-client.tsx
+++ b/components/fees/fees-list-client.tsx
@@ -155,7 +155,7 @@ export function FeesListClient() {
             </SheetTitle>
             <SheetDescription>
               {editTarget
-                ? `Perbarui tarif ${editTarget.feeType.toUpperCase()} tahun ${editTarget.year}.`
+                ? `Perbarui tarif ${editTarget.feeType.toUpperCase()} ${editTarget.year} Sem ${editTarget.semester === 1 ? 'Ganjil' : 'Genap'}.`
                 : 'Isi data untuk mendefinisikan tarif biaya baru.'}
             </SheetDescription>
           </SheetHeader>

--- a/components/fees/fees-list-client.tsx
+++ b/components/fees/fees-list-client.tsx
@@ -20,7 +20,13 @@ import type { FeeRow, FeeType } from '@/lib/validations/fee'
 
 const feeTypeOptions = [
   { value: 'all', label: 'Semua Tipe' },
+  { value: 'registration', label: 'Pendaftaran' },
   { value: 'spp', label: 'SPP' },
+  { value: 'building', label: 'Gedung' },
+  { value: 'uniform', label: 'Seragam' },
+  { value: 'book', label: 'Buku' },
+  { value: 'activity', label: 'Kegiatan' },
+  { value: 'other', label: 'Lainnya' },
 ]
 
 export function FeesListClient() {

--- a/components/fees/fees-table.tsx
+++ b/components/fees/fees-table.tsx
@@ -63,6 +63,7 @@ export function FeesTable({
           <TableHeader>
             <TableRow>
               <TableHead>Tahun Akademik</TableHead>
+              <TableHead>Semester</TableHead>
               <TableHead>Tipe Biaya</TableHead>
               <TableHead>Besaran</TableHead>
               <TableHead className="text-center">Jumlah Pembayaran</TableHead>
@@ -73,6 +74,7 @@ export function FeesTable({
             {data.map((fee) => (
               <TableRow key={fee.id}>
                 <TableCell className="font-medium">{fee.year}</TableCell>
+                <TableCell>{fee.semester === 1 ? 'Ganjil' : 'Genap'}</TableCell>
                 <TableCell>{feeTypeLabels[fee.feeType] ?? fee.feeType}</TableCell>
                 <TableCell>{formatRupiah(fee.amount)}</TableCell>
                 <TableCell className="text-center">{fee.paymentCount}</TableCell>

--- a/components/fees/fees-table.tsx
+++ b/components/fees/fees-table.tsx
@@ -22,8 +22,8 @@ interface FeesTableProps {
 }
 
 const feeTypeLabels: Record<string, string> = {
-  spp: 'SPP',
   registration: 'Pendaftaran',
+  spp: 'SPP',
   building: 'Gedung',
   uniform: 'Seragam',
   book: 'Buku',

--- a/drizzle/0004_dazzling_madame_web.sql
+++ b/drizzle/0004_dazzling_madame_web.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "fees" DROP CONSTRAINT "fees_type_year_unique";--> statement-breakpoint
+ALTER TABLE "fees" ADD COLUMN "semester" smallint DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "fees" ADD CONSTRAINT "fees_type_year_semester_unique" UNIQUE("fee_type","year","semester");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1511 @@
+{
+  "id": "904ab859-379b-48c9-a29d-ae678e9c2405",
+  "prevId": "f5d873c8-3be6-45e2-8c3e-b50e8702f968",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_payments": {
+      "name": "fee_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fee_id": {
+          "name": "fee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt": {
+          "name": "receipt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_file": {
+          "name": "receipt_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "paid_datetime": {
+          "name": "paid_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_payments_fee_id_fees_id_fk": {
+          "name": "fee_payments_fee_id_fees_id_fk",
+          "tableFrom": "fee_payments",
+          "tableTo": "fees",
+          "columnsFrom": [
+            "fee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fee_payments_student_id_students_id_fk": {
+          "name": "fee_payments_student_id_students_id_fk",
+          "tableFrom": "fee_payments",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fees": {
+      "name": "fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "fee_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester": {
+          "name": "semester",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fees_type_year_semester_unique": {
+          "name": "fees_type_year_semester_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "fee_type",
+            "year",
+            "semester"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutes": {
+      "name": "institutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "established_year": {
+          "name": "established_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "institute_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutes_name_unique": {
+          "name": "institutes_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "institutes_phone_unique": {
+          "name": "institutes_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        },
+        "institutes_email_unique": {
+          "name": "institutes_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staffs": {
+      "name": "staffs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institute_id": {
+          "name": "institute_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nik": {
+          "name": "nik",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staff_number": {
+          "name": "staff_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pob": {
+          "name": "pob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "department",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "staff_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staffs_user_id_users_id_fk": {
+          "name": "staffs_user_id_users_id_fk",
+          "tableFrom": "staffs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "staffs_institute_id_institutes_id_fk": {
+          "name": "staffs_institute_id_institutes_id_fk",
+          "tableFrom": "staffs",
+          "tableTo": "institutes",
+          "columnsFrom": [
+            "institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "staffs_nik_unique": {
+          "name": "staffs_nik_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nik"
+          ]
+        },
+        "staffs_staff_number_unique": {
+          "name": "staffs_staff_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "staff_number"
+          ]
+        },
+        "staffs_phone_unique": {
+          "name": "staffs_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        },
+        "staffs_email_unique": {
+          "name": "staffs_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institute_id": {
+          "name": "institute_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nik": {
+          "name": "nik",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nisn": {
+          "name": "nisn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pob": {
+          "name": "pob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_year": {
+          "name": "generation_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admission_date": {
+          "name": "admission_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "student_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "students_institute_id_institutes_id_fk": {
+          "name": "students_institute_id_institutes_id_fk",
+          "tableFrom": "students",
+          "tableTo": "institutes",
+          "columnsFrom": [
+            "institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_nik_unique": {
+          "name": "students_nik_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nik"
+          ]
+        },
+        "students_nisn_unique": {
+          "name": "students_nisn_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nisn"
+          ]
+        },
+        "students_student_number_unique": {
+          "name": "students_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_number"
+          ]
+        },
+        "students_phone_unique": {
+          "name": "students_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        },
+        "students_email_unique": {
+          "name": "students_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transfers": {
+      "name": "transfers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transfer_from_id": {
+          "name": "transfer_from_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transfer_to_id": {
+          "name": "transfer_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approver_id": {
+          "name": "approver_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "transfer_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "transfer_method": {
+          "name": "transfer_method",
+          "type": "transfer_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt": {
+          "name": "receipt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_file": {
+          "name": "receipt_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transfers_transfer_from_id_institutes_id_fk": {
+          "name": "transfers_transfer_from_id_institutes_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "institutes",
+          "columnsFrom": [
+            "transfer_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transfers_transfer_to_id_institutes_id_fk": {
+          "name": "transfers_transfer_to_id_institutes_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "institutes",
+          "columnsFrom": [
+            "transfer_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transfers_issuer_id_staffs_id_fk": {
+          "name": "transfers_issuer_id_staffs_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "staffs",
+          "columnsFrom": [
+            "issuer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transfers_sender_id_staffs_id_fk": {
+          "name": "transfers_sender_id_staffs_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "staffs",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transfers_receiver_id_staffs_id_fk": {
+          "name": "transfers_receiver_id_staffs_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "staffs",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transfers_approver_id_staffs_id_fk": {
+          "name": "transfers_approver_id_staffs_id_fk",
+          "tableFrom": "transfers",
+          "tableTo": "staffs",
+          "columnsFrom": [
+            "approver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subapps": {
+      "name": "subapps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institute_id": {
+          "name": "institute_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subapps_institute_id_institutes_id_fk": {
+          "name": "subapps_institute_id_institutes_id_fk",
+          "tableFrom": "subapps",
+          "tableTo": "institutes",
+          "columnsFrom": [
+            "institute_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subapps_key_unique": {
+          "name": "subapps_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subapps": {
+      "name": "user_subapps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subapp_id": {
+          "name": "subapp_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_subapps_user_id_subapp_id_index": {
+          "name": "user_subapps_user_id_subapp_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subapp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subapps_user_id_users_id_fk": {
+          "name": "user_subapps_user_id_users_id_fk",
+          "tableFrom": "user_subapps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_subapps_subapp_id_subapps_id_fk": {
+          "name": "user_subapps_subapp_id_subapps_id_fk",
+          "tableFrom": "user_subapps",
+          "tableTo": "subapps",
+          "columnsFrom": [
+            "subapp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.department": {
+      "name": "department",
+      "schema": "public",
+      "values": [
+        "academic",
+        "administration",
+        "finance",
+        "it",
+        "hr",
+        "other"
+      ]
+    },
+    "public.fee_type": {
+      "name": "fee_type",
+      "schema": "public",
+      "values": [
+        "registration",
+        "spp",
+        "building",
+        "uniform",
+        "book",
+        "activity",
+        "other"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.institute_type": {
+      "name": "institute_type",
+      "schema": "public",
+      "values": [
+        "foundation",
+        "school"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "transfer",
+        "virtual_account",
+        "qris",
+        "other"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "cancelled",
+        "refunded"
+      ]
+    },
+    "public.staff_status": {
+      "name": "staff_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "resigned"
+      ]
+    },
+    "public.student_status": {
+      "name": "student_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive",
+        "canceled",
+        "graduated",
+        "transferred",
+        "dropped"
+      ]
+    },
+    "public.transfer_method": {
+      "name": "transfer_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "bank_transfer",
+        "other"
+      ]
+    },
+    "public.transfer_status": {
+      "name": "transfer_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "superadmin",
+        "user"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775719065881,
       "tag": "0003_daily_richard_fisk",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1775801829184,
+      "tag": "0004_dazzling_madame_web",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema/fees.ts
+++ b/lib/db/schema/fees.ts
@@ -7,11 +7,12 @@ export const fees = pgTable(
     id: uuid('id').primaryKey().defaultRandom(),
     feeType: feeTypeEnum('fee_type').notNull(),
     year: smallint('year').notNull(),
+    semester: smallint('semester').notNull().default(1), // 1 = Ganjil, 2 = Genap
     amount: numeric('amount', { precision: 12, scale: 2 }).notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [unique('fees_type_year_unique').on(table.feeType, table.year)],
+  (table) => [unique('fees_type_year_semester_unique').on(table.feeType, table.year, table.semester)],
 )
 
 export type Fee = typeof fees.$inferSelect

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -91,6 +91,7 @@ export async function sendPaymentConfirmedEmail(
     studentNumber: string
     feeType: string
     feeYear: number
+    feeSemester: number
     amountPaid: string
     paymentMethod: string
     confirmedAt: Date
@@ -124,12 +125,15 @@ export async function sendPaymentConfirmedEmail(
       qris: 'QRIS',
     }
 
+    const semesterLabel = params.feeSemester === 1 ? 'Ganjil' : 'Genap'
+
     const html = buildPaymentConfirmedHtml({
       adminName: params.adminName,
       studentName: params.studentName,
       studentNumber: params.studentNumber,
       feeType: feeTypeLabel[params.feeType] ?? params.feeType,
       feeYear: params.feeYear,
+      feeSemester: semesterLabel,
       formattedAmount,
       paymentMethod: methodLabel[params.paymentMethod] ?? params.paymentMethod,
       formattedDate,
@@ -138,7 +142,7 @@ export async function sendPaymentConfirmedEmail(
     const { error } = await resend.emails.send({
       from: FROM_EMAIL,
       to,
-      subject: `[Konfirmasi Pembayaran] ${params.studentName} — ${feeTypeLabel[params.feeType] ?? params.feeType} ${params.feeYear}`,
+      subject: `[Konfirmasi Pembayaran] ${params.studentName} — ${feeTypeLabel[params.feeType] ?? params.feeType} ${params.feeYear} Sem ${semesterLabel}`,
       html,
     })
 
@@ -241,6 +245,7 @@ function buildPaymentConfirmedHtml(params: {
   studentNumber: string
   feeType: string
   feeYear: number
+  feeSemester: string
   formattedAmount: string
   paymentMethod: string
   formattedDate: string
@@ -287,6 +292,7 @@ function buildPaymentConfirmedHtml(params: {
                     ${buildDetailRow('No. Induk', escapeHtml(params.studentNumber))}
                     ${buildDetailRow('Jenis Biaya', params.feeType)}
                     ${buildDetailRow('Tahun', String(params.feeYear))}
+                    ${buildDetailRow('Semester', params.feeSemester)}
                     ${buildDetailRow('Jumlah Dibayar', `<strong style="color:#059669;font-size:16px;">${params.formattedAmount}</strong>`)}
                     ${buildDetailRow('Metode Pembayaran', params.paymentMethod)}
                     ${buildDetailRow('Dikonfirmasi Pada', params.formattedDate)}

--- a/lib/validations/fee-payment.ts
+++ b/lib/validations/fee-payment.ts
@@ -50,6 +50,7 @@ export type FeePaymentRow = {
   feeId: string
   feeType: string
   feeYear: number
+  feeSemester: number
   feeAmount: string
   amountPaid: string
   paymentMethod: PaymentMethod

--- a/lib/validations/fee.ts
+++ b/lib/validations/fee.ts
@@ -3,6 +3,12 @@ import { z } from 'zod'
 export const feeTypeValues = ['spp'] as const
 export type FeeType = (typeof feeTypeValues)[number]
 
+const semesterField = z
+  .number()
+  .int('Semester harus bilangan bulat')
+  .min(1, 'Semester minimal 1')
+  .max(2, 'Semester maksimal 2')
+
 export const createFeeSchema = z.object({
   feeType: z.enum(feeTypeValues, { message: 'Tipe biaya tidak valid' }),
   year: z
@@ -10,6 +16,7 @@ export const createFeeSchema = z.object({
     .int('Tahun akademik harus bilangan bulat')
     .min(2000, 'Tahun akademik minimal 2000')
     .max(2100, 'Tahun akademik tidak valid'),
+  semester: semesterField,
   amount: z
     .string()
     .min(1, 'Besaran biaya wajib diisi')
@@ -23,6 +30,7 @@ export const updateFeeSchema = z.object({
     .int('Tahun akademik harus bilangan bulat')
     .min(2000, 'Tahun akademik minimal 2000')
     .max(2100, 'Tahun akademik tidak valid'),
+  semester: semesterField,
   amount: z
     .string()
     .min(1, 'Besaran biaya wajib diisi')
@@ -34,6 +42,7 @@ export const getFeesSchema = z.object({
   perPage: z.number().int().min(1).max(100).default(10),
   feeType: z.enum(feeTypeValues).optional(),
   year: z.number().int().optional(),
+  semester: z.number().int().min(1).max(2).optional(),
 })
 
 export type CreateFeeInput = z.infer<typeof createFeeSchema>
@@ -44,6 +53,7 @@ export type FeeRow = {
   id: string
   feeType: FeeType
   year: number
+  semester: number
   amount: string
   paymentCount: number
   createdAt: Date

--- a/lib/validations/fee.ts
+++ b/lib/validations/fee.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod'
 
-export const feeTypeValues = ['spp'] as const
+export const feeTypeValues = [
+  'registration',
+  'spp',
+  'building',
+  'uniform',
+  'book',
+  'activity',
+  'other',
+] as const
 export type FeeType = (typeof feeTypeValues)[number]
 
 const semesterField = z


### PR DESCRIPTION
## Ringkasan Perubahan

### feat: Ubah tarif SPP dari per tahun menjadi per semester
- Tambah kolom `semester` (1=Ganjil, 2=Genap) di tabel `fees`
- Update unique constraint: `(feeType, year)` → `(feeType, year, semester)`
- Update form tarif: tambah dropdown pilih semester
- Update tabel daftar tarif: tampilkan kolom Semester
- Update dropdown pilih tarif di form pembayaran: label sertakan semester
- Update email konfirmasi pembayaran: sertakan info semester
- Migration DB sudah dijalankan (`drizzle/0004_dazzling_madame_web.sql`)

### fix: QA issue #22 — data isolation & fee type enum
- **Fix `getStudentById`**: filter by `scopedInstituteId` saat dipanggil dengan `subAppKey` (sebelumnya bisa ambil siswa dari institusi lain)
- **Fix `updateStudent`**: validasi kepemilikan siswa sebelum update
- **Fix `getStaffById`**: filter by `scopedInstituteId` saat dipanggil dengan `subAppKey`
- **Fix `updateStaff`**: validasi kepemilikan staf sebelum update
- **Fix `feeTypeValues`**: sebelumnya hanya `['spp']`, sekarang semua 7 tipe sesuai DB enum (`registration`, `spp`, `building`, `uniform`, `book`, `activity`, `other`)
- Update dropdown tipe biaya di form: tampilkan semua tipe
- Update filter tipe biaya di list: tampilkan semua opsi

## Hasil Test Plan
```
TypeScript check: pnpm tsc --noEmit → Exit 0 (tidak ada error)
DB migration: applied successfully
```

## Checklist
- [x] Schema DB diupdate + migration dijalankan
- [x] Data isolation diperbaiki di getStudentById, updateStudent, getStaffById, updateStaff
- [x] Fee type enum konsisten antara DB schema dan validasi
- [x] TypeScript check passed
- [x] Tidak ada breaking change pada API yang sudah ada