### PR TITLE
fix: update UserRole type to include foundation and school roles (#49)

### DIFF
--- a/app/(dashboard)/foundation/[subAppKey]/layout.tsx
+++ b/app/(dashboard)/foundation/[subAppKey]/layout.tsx
@@ -3,8 +3,7 @@ import { requireSubappAccess, getUserSubapps } from '@/lib/auth-helpers'
 import { Header } from '@/components/layout/header'
 import { SidebarDesktop } from '@/components/layout/sidebar'
 import type { Subapp } from '@/lib/db/schema'
-
-type UserRole = 'superadmin' | 'user'
+import type { UserRole } from '@/lib/auth-helpers'
 
 export default async function FoundationSubappLayout(
   props: LayoutProps<'/foundation/[subAppKey]'>
@@ -27,7 +26,7 @@ export default async function FoundationSubappLayout(
   }
 
   const { user } = session
-  const userRole = ((user as { role?: string }).role ?? 'user') as UserRole
+  const userRole = (user as { role?: UserRole }).role ?? 'school'
 
   let subapps: Subapp[] = []
   try {

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,9 +1,8 @@
 import { redirect } from 'next/navigation'
 import { requireAuth, getUserSubapps } from '@/lib/auth-helpers'
+import type { UserRole } from '@/lib/auth-helpers'
 import { Header } from '@/components/layout/header'
 import { SidebarDesktop } from '@/components/layout/sidebar'
-
-type UserRole = 'superadmin' | 'user'
 
 export default async function DashboardLayout({
   children,
@@ -19,7 +18,7 @@ export default async function DashboardLayout({
   }
 
   const { user } = session
-  const userRole = ((user as { role?: string }).role ?? 'user') as UserRole
+  const userRole = (user as { role?: UserRole }).role ?? 'school'
 
   let subapps: Awaited<ReturnType<typeof getUserSubapps>> = []
 

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -2,12 +2,11 @@ import { redirect } from 'next/navigation'
 import Image from 'next/image'
 import Link from 'next/link'
 import { requireAuth, getUserSubapps } from '@/lib/auth-helpers'
+import type { UserRole } from '@/lib/auth-helpers'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 import type { Subapp } from '@/lib/db/schema'
-
-type UserRole = 'superadmin' | 'user'
 
 const TYPE_LABEL: Record<string, string> = {
   foundation: 'Yayasan',
@@ -39,7 +38,7 @@ export default async function DashboardPortalPage() {
   }
 
   const { user } = session
-  const userRole = ((user as { role?: string }).role ?? 'user') as UserRole
+  const userRole = (user as { role?: UserRole }).role ?? 'school'
 
   let subappList: Subapp[] = []
 

--- a/app/(dashboard)/school/[subAppKey]/layout.tsx
+++ b/app/(dashboard)/school/[subAppKey]/layout.tsx
@@ -3,8 +3,7 @@ import { requireSubappAccess, getUserSubapps } from '@/lib/auth-helpers'
 import { Header } from '@/components/layout/header'
 import { SidebarDesktop } from '@/components/layout/sidebar'
 import type { Subapp } from '@/lib/db/schema'
-
-type UserRole = 'superadmin' | 'user'
+import type { UserRole } from '@/lib/auth-helpers'
 
 export default async function SchoolSubappLayout(
   props: LayoutProps<'/school/[subAppKey]'>
@@ -27,7 +26,7 @@ export default async function SchoolSubappLayout(
   }
 
   const { user } = session
-  const userRole = ((user as { role?: string }).role ?? 'user') as UserRole
+  const userRole = (user as { role?: UserRole }).role ?? 'school'
 
   let subapps: Subapp[] = []
   try {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -24,9 +24,8 @@ import {
 import { DashboardBreadcrumb } from '@/components/layout/breadcrumb'
 import { SidebarContent } from '@/components/layout/sidebar'
 import { SubAppSwitcher, type SubappItem } from '@/components/layout/subapp-switcher'
+import type { UserRole } from '@/lib/auth-helpers'
 import { useState } from 'react'
-
-type UserRole = 'superadmin' | 'user'
 
 interface HeaderProps {
   userName: string
@@ -50,7 +49,8 @@ function getInitials(name: string): string {
 
 const ROLE_LABELS: Record<UserRole, string> = {
   superadmin: 'Superadmin',
-  user: 'Pengguna',
+  foundation: 'Yayasan',
+  school: 'Sekolah',
 }
 
 export function Header({

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -12,8 +12,7 @@ import {
   SchoolIcon,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-
-type UserRole = 'superadmin' | 'user'
+import type { UserRole } from '@/lib/auth-helpers'
 
 interface NavItem {
   label: string
@@ -22,8 +21,8 @@ interface NavItem {
 }
 
 // Nav items untuk superadmin.
-// User (foundation/school) mendapatkan nav dari sub-app specific layout.
-const NAV_ITEMS: Record<UserRole, NavItem[]> = {
+// Foundation/school mendapatkan nav dari sub-app specific layout.
+const NAV_ITEMS: Partial<Record<UserRole, NavItem[]>> = {
   superadmin: [
     {
       label: 'Institusi',
@@ -56,7 +55,8 @@ const NAV_ITEMS: Record<UserRole, NavItem[]> = {
       icon: <ArrowLeftRightIcon className="size-4" />,
     },
   ],
-  user: [],
+  foundation: [],
+  school: [],
 }
 
 function getSchoolNavItems(subAppKey: string): NavItem[] {
@@ -108,7 +108,7 @@ interface SidebarNavProps {
 
 export function SidebarNav({ role, onNavigate, subAppKey, subappType }: SidebarNavProps) {
   const pathname = usePathname()
-  const items = subAppKey && role === 'user'
+  const items = subAppKey && (role === 'foundation' || role === 'school')
     ? subappType === 'foundation'
       ? getFoundationNavItems(subAppKey)
       : getSchoolNavItems(subAppKey)

--- a/components/layout/subapp-switcher.tsx
+++ b/components/layout/subapp-switcher.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import type { UserRole } from '@/lib/auth-helpers'
 
 export type SubappItem = {
   id: string
@@ -24,7 +25,7 @@ export type SubappItem = {
 }
 
 interface SubAppSwitcherProps {
-  userRole: 'superadmin' | 'user'
+  userRole: UserRole
   subapps: SubappItem[]
   currentKey?: string | null
 }

--- a/lib/auth-helpers.ts
+++ b/lib/auth-helpers.ts
@@ -4,7 +4,7 @@ import { auth } from './auth'
 import { db } from './db'
 import { staffs, subapps, userSubapps } from './db/schema'
 
-export type UserRole = 'superadmin' | 'user'
+export type UserRole = 'superadmin' | 'foundation' | 'school'
 
 /**
  * Memastikan pengguna sudah login. Melempar error jika belum.

--- a/lib/db/schema/enums.ts
+++ b/lib/db/schema/enums.ts
@@ -1,6 +1,6 @@
 import { pgEnum } from 'drizzle-orm/pg-core'
 
-export const userRoleEnum = pgEnum('user_role', ['superadmin', 'user'])
+export const userRoleEnum = pgEnum('user_role', ['superadmin', 'foundation', 'school'])
 
 export const instituteTypeEnum = pgEnum('institute_type', [
   'foundation',

--- a/lib/db/schema/users.ts
+++ b/lib/db/schema/users.ts
@@ -8,7 +8,7 @@ export const users = pgTable('users', {
   emailVerified: boolean('email_verified').notNull().default(false),
   password: text('password'),
   avatar: text('avatar'),
-  role: userRoleEnum('role').notNull().default('user'),
+  role: userRoleEnum('role').notNull().default('school'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 })

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
-
-type UserRole = 'superadmin' | 'user'
+import type { UserRole } from '@/lib/auth-helpers'
 
 const PUBLIC_ROUTES = [
   '/login',

--- a/tests/helpers/auth-mock.ts
+++ b/tests/helpers/auth-mock.ts
@@ -33,7 +33,7 @@ export const USER_SESSION = {
     id: 'regular-user-id',
     name: 'Regular User',
     email: 'user@example.com',
-    role: 'user',
+    role: 'school',
     emailVerified: true,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -60,7 +60,7 @@ export const USER_SESSION = {
     id: REGULAR_USER_ID,
     name: 'Regular User',
     email: 'user@example.com',
-    role: 'user',
+    role: 'school',
     emailVerified: true,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/tests/lib/auth-helpers.test.ts
+++ b/tests/lib/auth-helpers.test.ts
@@ -46,7 +46,7 @@ describe('lib/auth-helpers', () => {
     user: { id: 'sa-1', role: 'superadmin', name: 'Super Admin' },
   }
   const USER_SESSION = {
-    user: { id: 'u-1', role: 'user', name: 'Regular User' },
+    user: { id: 'u-1', role: 'school', name: 'Regular User' },
   }
   const SUBAPP = { id: 'sub-1', key: 'school-1', name: 'Sekolah 1' }
 


### PR DESCRIPTION
## Terkait Issue
Closes #49

## Ringkasan Perubahan
- Fix tipe `UserRole` di `lib/auth-helpers.ts` dari `'superadmin' | 'user'` menjadi `'superadmin' | 'foundation' | 'school'`
- Hapus semua deklarasi `type UserRole` lokal di 4 layout file, header, sidebar, subapp-switcher, dan proxy — ganti dengan import dari `@/lib/auth-helpers`
- Update `ROLE_LABELS` di `header.tsx`: hapus entry `user: 'Pengguna'`, tambah `foundation: 'Yayasan'` dan `school: 'Sekolah'`
- Update `NAV_ITEMS` di `sidebar.tsx`: hapus key `user`, tambah `foundation` dan `school` (keduanya empty karena nav mereka datang dari sub-app layout)
- Fix logika kondisi di `sidebar.tsx`: `role === 'user'` → `role === 'foundation' || role === 'school'`
- Update DB enum `userRoleEnum` di `lib/db/schema/enums.ts` dari `['superadmin', 'user']` ke `['superadmin', 'foundation', 'school']`
- Update default role di `lib/db/schema/users.ts` dari `'user'` ke `'school'`
- Update test fixtures dan mock helpers: `USER_SESSION.role: 'user'` → `'school'`

## Hasil Test Plan
```
pnpm tsc --noEmit
# Exit 0, tidak ada error
```

## Checklist
- [x] Tipe `UserRole` sudah benar di `lib/auth-helpers.ts`
- [x] Tidak ada lagi definisi lokal `type UserRole = 'superadmin' | 'user'`
- [x] DB enum diperbarui sesuai role yang valid
- [x] Semua komponen UI menggunakan tipe yang konsisten
- [x] Test fixtures dan mock diperbarui
- [x] TypeScript check lulus tanpa error