### PR TITLE
fix: revert wrong UserRole type — kembalikan ke superadmin|user design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,19 +17,23 @@ Issue development ada di **GitHub: https://github.com/Ariwira/school-system/issu
 
 ### Autentikasi & RBAC
 - **Tidak menggunakan organization plugin** dari Better Auth
-- RBAC cukup pakai `role` di tabel `users` + `instituteId` di tabel `staffs`
-- Roles: `superadmin` | `foundation` | `school`
+- RBAC menggunakan `role` di tabel `users` + tabel `user_subapps` (SubApp sebagai proxy RBAC)
+- Roles di `users.role`: `superadmin` | `user`
+  - `superadmin` → akses penuh ke seluruh platform
+  - `user` → akses ditentukan dari `user_subapps`, role efektif dari `subapp.type` (`foundation` atau `school`)
 - RBAC ditegakkan di **3 lapisan**: middleware → layout → Server Action
 - **Jangan pernah trust data dari client** — selalu re-validasi di Server Action
 
 ### Data Isolation (WAJIB di setiap Server Action)
 ```ts
 // Superadmin → bisa lihat semua
-// Foundation/School → hanya data institusinya sendiri
-const session = await requireRole(['superadmin', 'foundation', 'school'])
-if (session.user.role !== 'superadmin') {
-  const instituteId = await getUserInstituteId(session.user.id)
-  // filter query berdasarkan instituteId
+// User biasa → akses via subapp, role efektif dari subapp.type
+const { subapp } = await requireSubappAccess(subAppKey)
+const scopedInstituteId = subapp.instituteId
+
+// Setelah fetch record:
+if (existing.instituteId !== scopedInstituteId) {
+  return { success: false, error: 'Akses ditolak.' }
 }
 ```
 

--- a/app/(dashboard)/foundation/[subAppKey]/layout.tsx
+++ b/app/(dashboard)/foundation/[subAppKey]/layout.tsx
@@ -26,7 +26,7 @@ export default async function FoundationSubappLayout(
   }
 
   const { user } = session
-  const userRole = (user as { role?: UserRole }).role ?? 'school'
+  const userRole = (user as { role?: UserRole }).role ?? 'user'
 
   let subapps: Subapp[] = []
   try {

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -18,7 +18,7 @@ export default async function DashboardLayout({
   }
 
   const { user } = session
-  const userRole = (user as { role?: UserRole }).role ?? 'school'
+  const userRole = (user as { role?: UserRole }).role ?? 'user'
 
   let subapps: Awaited<ReturnType<typeof getUserSubapps>> = []
 

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -38,7 +38,7 @@ export default async function DashboardPortalPage() {
   }
 
   const { user } = session
-  const userRole = (user as { role?: UserRole }).role ?? 'school'
+  const userRole = (user as { role?: UserRole }).role ?? 'user'
 
   let subappList: Subapp[] = []
 

--- a/app/(dashboard)/school/[subAppKey]/layout.tsx
+++ b/app/(dashboard)/school/[subAppKey]/layout.tsx
@@ -26,7 +26,7 @@ export default async function SchoolSubappLayout(
   }
 
   const { user } = session
-  const userRole = (user as { role?: UserRole }).role ?? 'school'
+  const userRole = (user as { role?: UserRole }).role ?? 'user'
 
   let subapps: Subapp[] = []
   try {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -49,6 +49,10 @@ function getInitials(name: string): string {
 
 const ROLE_LABELS: Record<UserRole, string> = {
   superadmin: 'Superadmin',
+  user: 'Pengguna',
+}
+
+const SUBAPP_TYPE_LABELS: Record<string, string> = {
   foundation: 'Yayasan',
   school: 'Sekolah',
 }
@@ -129,7 +133,7 @@ export function Header({
                 </span>
                 <span className="text-xs text-muted-foreground">{userEmail}</span>
                 <span className="text-xs text-muted-foreground">
-                  {ROLE_LABELS[userRole]}
+                  {userRole === 'user' && subappType ? (SUBAPP_TYPE_LABELS[subappType] ?? ROLE_LABELS[userRole]) : ROLE_LABELS[userRole]}
                 </span>
               </div>
             </DropdownMenuLabel>

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -55,8 +55,7 @@ const NAV_ITEMS: Partial<Record<UserRole, NavItem[]>> = {
       icon: <ArrowLeftRightIcon className="size-4" />,
     },
   ],
-  foundation: [],
-  school: [],
+  user: [],
 }
 
 function getSchoolNavItems(subAppKey: string): NavItem[] {
@@ -108,7 +107,7 @@ interface SidebarNavProps {
 
 export function SidebarNav({ role, onNavigate, subAppKey, subappType }: SidebarNavProps) {
   const pathname = usePathname()
-  const items = subAppKey && (role === 'foundation' || role === 'school')
+  const items = subAppKey && role === 'user'
     ? subappType === 'foundation'
       ? getFoundationNavItems(subAppKey)
       : getSchoolNavItems(subAppKey)

--- a/lib/auth-helpers.ts
+++ b/lib/auth-helpers.ts
@@ -4,7 +4,7 @@ import { auth } from './auth'
 import { db } from './db'
 import { staffs, subapps, userSubapps } from './db/schema'
 
-export type UserRole = 'superadmin' | 'foundation' | 'school'
+export type UserRole = 'superadmin' | 'user'
 
 /**
  * Memastikan pengguna sudah login. Melempar error jika belum.

--- a/lib/db/schema/enums.ts
+++ b/lib/db/schema/enums.ts
@@ -1,6 +1,6 @@
 import { pgEnum } from 'drizzle-orm/pg-core'
 
-export const userRoleEnum = pgEnum('user_role', ['superadmin', 'foundation', 'school'])
+export const userRoleEnum = pgEnum('user_role', ['superadmin', 'user'])
 
 export const instituteTypeEnum = pgEnum('institute_type', [
   'foundation',

--- a/lib/db/schema/users.ts
+++ b/lib/db/schema/users.ts
@@ -8,7 +8,7 @@ export const users = pgTable('users', {
   emailVerified: boolean('email_verified').notNull().default(false),
   password: text('password'),
   avatar: text('avatar'),
-  role: userRoleEnum('role').notNull().default('school'),
+  role: userRoleEnum('role').notNull().default('user'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 })

--- a/tests/helpers/auth-mock.ts
+++ b/tests/helpers/auth-mock.ts
@@ -33,7 +33,7 @@ export const USER_SESSION = {
     id: 'regular-user-id',
     name: 'Regular User',
     email: 'user@example.com',
-    role: 'school',
+    role: 'user',
     emailVerified: true,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -60,7 +60,7 @@ export const USER_SESSION = {
     id: REGULAR_USER_ID,
     name: 'Regular User',
     email: 'user@example.com',
-    role: 'school',
+    role: 'user',
     emailVerified: true,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/tests/lib/auth-helpers.test.ts
+++ b/tests/lib/auth-helpers.test.ts
@@ -46,7 +46,7 @@ describe('lib/auth-helpers', () => {
     user: { id: 'sa-1', role: 'superadmin', name: 'Super Admin' },
   }
   const USER_SESSION = {
-    user: { id: 'u-1', role: 'school', name: 'Regular User' },
+    user: { id: 'u-1', role: 'user', name: 'Regular User' },
   }
   const SUBAPP = { id: 'sub-1', key: 'school-1', name: 'Sekolah 1' }
 


### PR DESCRIPTION
## Latar Belakang

PR #54 (issue #49) salah mengubah `UserRole` menjadi `'superadmin' | 'foundation' | 'school'` karena mengacu CLAUDE.md yang outdated. Design yang benar sudah ditetapkan di issue #29:

- `users.role`: hanya `superadmin` atau `user`
- Role efektif (`foundation`/`school`) ditentukan dari `subapp.type` via tabel `user_subapps`

## Perubahan

- Kembalikan `UserRole` ke `'superadmin' | 'user'` di `lib/auth-helpers.ts`
- Kembalikan DB enum `user_role` ke `['superadmin', 'user']` di `lib/db/schema/enums.ts`
- Kembalikan default role di `lib/db/schema/users.ts` ke `'user'`
- Fix `sidebar.tsx`: hapus key `foundation`/`school` dari `NAV_ITEMS`, tambah key `user`
- Fix `header.tsx`: `ROLE_LABELS` hanya `superadmin`/`user`, label Yayasan/Sekolah dari `subappType`
- Fix semua `?? 'school'` fallback ke `?? 'user'` di layout files (4 file)
- Fix test fixtures & mocks: `role: 'school'` → `role: 'user'`
- Update `CLAUDE.md` dengan penjelasan design RBAC yang benar

## Hasil Test Plan

```
pnpm tsc --noEmit   → exit 0, tidak ada error TypeScript
pnpm test           → 203 passed (11 test files)
```

## Checklist

- [x] `UserRole` = `'superadmin' | 'user'` (sesuai design issue #29)
- [x] DB enum tidak berubah dari kondisi production
- [x] Semua komponen UI masih berfungsi dengan benar
- [x] CLAUDE.md diupdate agar tidak menyesatkan di masa depan
- [x] TypeScript check lulus
- [x] Semua test lulus