### PR TITLE
fix: ganti tombol aksi inline dengan dropdown dan perlebar sheet form (#58)

### DIFF
--- a/components/fee-payments/fee-payments-list-client.tsx
+++ b/components/fee-payments/fee-payments-list-client.tsx
@@ -183,7 +183,7 @@ export function FeePaymentsListClient({ subAppKey }: FeePaymentsListClientProps)
 
       {/* Sheet form tambah pembayaran */}
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
+        <SheetContent className="w-full sm:max-w-xl overflow-y-auto">
           <SheetHeader>
             <SheetTitle>Catat Pembayaran SPP</SheetTitle>
             <SheetDescription>

--- a/components/fee-payments/fee-payments-table.tsx
+++ b/components/fee-payments/fee-payments-table.tsx
@@ -1,10 +1,18 @@
 'use client'
 
 import { useState, useTransition, useCallback } from 'react'
-import { CheckCircleIcon, ExternalLinkIcon } from 'lucide-react'
+import { CheckCircleIcon, ExternalLinkIcon, MoreHorizontalIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import {
   Table,
   TableBody,
@@ -168,29 +176,52 @@ export function FeePaymentsTable({
                       {formatDateWITA(payment.paidDatetime)}
                     </TableCell>
                     <TableCell className="text-right">
-                      <div className="flex justify-end gap-1.5 flex-wrap">
-                        {payment.receiptFile && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            render={<a href={payment.receiptFile} target="_blank" rel="noopener noreferrer" />}
-                          >
-                            <ExternalLinkIcon className="size-3.5 mr-1" />
-                            Bukti
-                          </Button>
-                        )}
-                        {payment.status === 'pending' && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setConfirmTarget(payment)}
-                            disabled={isPending}
-                          >
-                            <CheckCircleIcon className="size-3.5 mr-1" />
-                            Konfirmasi
-                          </Button>
-                        )}
-                      </div>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          render={<Button variant="outline" size="icon-sm" />}
+                          disabled={isPending}
+                        >
+                          <MoreHorizontalIcon className="size-4" />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-44">
+                          {payment.receiptFile ? (
+                            <>
+                              <DropdownMenuGroup>
+                                <DropdownMenuItem
+                                  render={<a href={payment.receiptFile} target="_blank" rel="noopener noreferrer" />}
+                                >
+                                  <ExternalLinkIcon className="size-4" />
+                                  Lihat Bukti
+                                </DropdownMenuItem>
+                              </DropdownMenuGroup>
+                              {payment.status === 'pending' && (
+                                <>
+                                  <DropdownMenuSeparator />
+                                  <DropdownMenuGroup>
+                                    <DropdownMenuItem onClick={() => setConfirmTarget(payment)}>
+                                      <CheckCircleIcon className="size-4" />
+                                      Konfirmasi
+                                    </DropdownMenuItem>
+                                  </DropdownMenuGroup>
+                                </>
+                              )}
+                            </>
+                          ) : (
+                            <DropdownMenuGroup>
+                              {payment.status === 'pending' ? (
+                                <DropdownMenuItem onClick={() => setConfirmTarget(payment)}>
+                                  <CheckCircleIcon className="size-4" />
+                                  Konfirmasi
+                                </DropdownMenuItem>
+                              ) : (
+                                <DropdownMenuItem disabled>
+                                  <span className="text-muted-foreground text-sm">Tidak ada aksi</span>
+                                </DropdownMenuItem>
+                              )}
+                            </DropdownMenuGroup>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </TableCell>
                   </TableRow>
                 )

--- a/components/fees/fees-list-client.tsx
+++ b/components/fees/fees-list-client.tsx
@@ -154,7 +154,7 @@ export function FeesListClient() {
 
       {/* Sheet form tambah/edit */}
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent className="w-full sm:max-w-md overflow-y-auto">
+        <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
           <SheetHeader>
             <SheetTitle>
               {editTarget ? 'Edit Tarif Biaya' : 'Tambah Tarif Biaya'}

--- a/components/institutes/institutes-table.tsx
+++ b/components/institutes/institutes-table.tsx
@@ -3,9 +3,17 @@
 import { useState, useTransition, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { PencilIcon, PowerOffIcon } from 'lucide-react'
+import { PencilIcon, PowerOffIcon, MoreHorizontalIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import {
   Table,
   TableBody,
@@ -115,26 +123,34 @@ export function InstitutesTable({
                     {formatDate(institute.createdAt)}
                   </TableCell>
                   <TableCell className="text-right">
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() =>
-                          router.push(`/superadmin/institutes/${institute.id}`)
-                        }
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={<Button variant="outline" size="icon-sm" />}
+                        disabled={isPending}
                       >
-                        <PencilIcon className="size-3.5 mr-1" />
-                        Edit
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setDeactivateTarget(institute)}
-                      >
-                        <PowerOffIcon className="size-3.5 mr-1" />
-                        Nonaktifkan
-                      </Button>
-                    </div>
+                        <MoreHorizontalIcon className="size-4" />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-44">
+                        <DropdownMenuGroup>
+                          <DropdownMenuItem
+                            onClick={() => router.push(`/superadmin/institutes/${institute.id}`)}
+                          >
+                            <PencilIcon className="size-4" />
+                            Edit
+                          </DropdownMenuItem>
+                        </DropdownMenuGroup>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuGroup>
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onClick={() => setDeactivateTarget(institute)}
+                          >
+                            <PowerOffIcon className="size-4" />
+                            Nonaktifkan
+                          </DropdownMenuItem>
+                        </DropdownMenuGroup>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </TableCell>
                 </TableRow>
               ))

--- a/components/staffs/staffs-list-client.tsx
+++ b/components/staffs/staffs-list-client.tsx
@@ -178,7 +178,7 @@ export function StaffsListClient({
 
       {/* Sheet form untuk tambah/edit staf */}
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
+        <SheetContent className="w-full sm:max-w-xl overflow-y-auto">
           <SheetHeader>
             <SheetTitle>
               {editTarget ? 'Edit Staf' : 'Tambah Staf Baru'}

--- a/components/staffs/staffs-table.tsx
+++ b/components/staffs/staffs-table.tsx
@@ -6,11 +6,20 @@ import {
   UserCheckIcon,
   UserXIcon,
   PencilIcon,
-  ToggleLeftIcon,
-  ToggleRightIcon,
+  PowerOffIcon,
+  PowerIcon,
+  MoreHorizontalIcon,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import {
   Table,
   TableBody,
@@ -165,60 +174,57 @@ export function StaffsTable({
                       )}
                     </TableCell>
                     <TableCell className="text-right">
-                      <div className="flex justify-end gap-1.5">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => onEdit(staff)}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          render={<Button variant="outline" size="icon-sm" />}
                           disabled={isPending}
                         >
-                          <PencilIcon className="size-3.5 mr-1" />
-                          Edit
-                        </Button>
-
-                        {staff.userId ? (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setUnlinkTarget(staff)}
-                            disabled={isPending}
-                          >
-                            <UserXIcon className="size-3.5 mr-1" />
-                            Lepas Akun
-                          </Button>
-                        ) : (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => onLinkUser(staff)}
-                            disabled={isPending}
-                          >
-                            <UserCheckIcon className="size-3.5 mr-1" />
-                            Link Akun
-                          </Button>
-                        )}
-
-                        {staff.status !== 'resigned' && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setToggleTarget(staff)}
-                            disabled={isPending}
-                          >
-                            {staff.status === 'active' ? (
-                              <>
-                                <ToggleRightIcon className="size-3.5 mr-1" />
-                                Nonaktifkan
-                              </>
+                          <MoreHorizontalIcon className="size-4" />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-44">
+                          <DropdownMenuGroup>
+                            <DropdownMenuItem onClick={() => onEdit(staff)}>
+                              <PencilIcon className="size-4" />
+                              Edit
+                            </DropdownMenuItem>
+                            {staff.userId ? (
+                              <DropdownMenuItem
+                                variant="destructive"
+                                onClick={() => setUnlinkTarget(staff)}
+                              >
+                                <UserXIcon className="size-4" />
+                                Lepas Akun
+                              </DropdownMenuItem>
                             ) : (
-                              <>
-                                <ToggleLeftIcon className="size-3.5 mr-1" />
-                                Aktifkan
-                              </>
+                              <DropdownMenuItem onClick={() => onLinkUser(staff)}>
+                                <UserCheckIcon className="size-4" />
+                                Link Akun
+                              </DropdownMenuItem>
                             )}
-                          </Button>
-                        )}
-                      </div>
+                          </DropdownMenuGroup>
+                          {staff.status !== 'resigned' && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuGroup>
+                                {staff.status === 'active' ? (
+                                  <DropdownMenuItem
+                                    variant="destructive"
+                                    onClick={() => setToggleTarget(staff)}
+                                  >
+                                    <PowerOffIcon className="size-4" />
+                                    Nonaktifkan
+                                  </DropdownMenuItem>
+                                ) : (
+                                  <DropdownMenuItem onClick={() => setToggleTarget(staff)}>
+                                    <PowerIcon className="size-4" />
+                                    Aktifkan
+                                  </DropdownMenuItem>
+                                )}
+                              </DropdownMenuGroup>
+                            </>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </TableCell>
                   </TableRow>
                 )

--- a/components/students/students-list-client.tsx
+++ b/components/students/students-list-client.tsx
@@ -180,7 +180,7 @@ export function StudentsListClient({
 
       {/* Sheet form tambah/edit */}
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
+        <SheetContent className="w-full sm:max-w-xl overflow-y-auto">
           <SheetHeader>
             <SheetTitle>
               {editTarget ? 'Edit Siswa' : 'Tambah Siswa Baru'}

--- a/components/students/students-table.tsx
+++ b/components/students/students-table.tsx
@@ -9,9 +9,18 @@ import {
   XCircleIcon,
   BanIcon,
   EyeIcon,
+  MoreHorizontalIcon,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import {
   Table,
   TableBody,
@@ -118,79 +127,6 @@ export function StudentsTable({
     return `/superadmin/students/${student.id}`
   }
 
-  function getActionButtons(student: StudentRow) {
-    const buttons: React.ReactNode[] = []
-
-    buttons.push(
-      <Button
-        key="detail"
-        variant="outline"
-        size="sm"
-        render={<Link href={getDetailHref(student)} />}
-      >
-        <EyeIcon className="size-3.5 mr-1" />
-        Detail
-      </Button>,
-    )
-
-    buttons.push(
-      <Button
-        key="edit"
-        variant="outline"
-        size="sm"
-        onClick={() => onEdit(student)}
-        disabled={isPending}
-      >
-        <PencilIcon className="size-3.5 mr-1" />
-        Edit
-      </Button>,
-    )
-
-    if (student.status === 'pending') {
-      buttons.push(
-        <Button
-          key="activate"
-          variant="outline"
-          size="sm"
-          onClick={() => setConfirmAction({ type: 'activate', student })}
-          disabled={isPending}
-        >
-          <CheckCircleIcon className="size-3.5 mr-1" />
-          Aktifkan
-        </Button>,
-      )
-      buttons.push(
-        <Button
-          key="cancel"
-          variant="outline"
-          size="sm"
-          onClick={() => setConfirmAction({ type: 'cancel', student })}
-          disabled={isPending}
-        >
-          <BanIcon className="size-3.5 mr-1" />
-          Batalkan
-        </Button>,
-      )
-    }
-
-    if (student.status === 'active') {
-      buttons.push(
-        <Button
-          key="deactivate"
-          variant="outline"
-          size="sm"
-          onClick={() => setConfirmAction({ type: 'deactivate', student })}
-          disabled={isPending}
-        >
-          <XCircleIcon className="size-3.5 mr-1" />
-          Nonaktifkan
-        </Button>,
-      )
-    }
-
-    return buttons
-  }
-
   function getConfirmDialogContent() {
     if (!confirmAction) return null
     const { type, student } = confirmAction
@@ -284,9 +220,59 @@ export function StudentsTable({
                       <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
                     </TableCell>
                     <TableCell className="text-right">
-                      <div className="flex justify-end gap-1.5 flex-wrap">
-                        {getActionButtons(student)}
-                      </div>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          render={<Button variant="outline" size="icon-sm" />}
+                          disabled={isPending}
+                        >
+                          <MoreHorizontalIcon className="size-4" />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-44">
+                          <DropdownMenuGroup>
+                            <DropdownMenuItem render={<Link href={getDetailHref(student)} />}>
+                              <EyeIcon className="size-4" />
+                              Detail Siswa
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => onEdit(student)}>
+                              <PencilIcon className="size-4" />
+                              Edit Data
+                            </DropdownMenuItem>
+                          </DropdownMenuGroup>
+                          {(student.status === 'pending' || student.status === 'active') && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuGroup>
+                                {student.status === 'pending' && (
+                                  <DropdownMenuItem
+                                    onClick={() => setConfirmAction({ type: 'activate', student })}
+                                  >
+                                    <CheckCircleIcon className="size-4" />
+                                    Aktifkan
+                                  </DropdownMenuItem>
+                                )}
+                                {student.status === 'active' && (
+                                  <DropdownMenuItem
+                                    variant="destructive"
+                                    onClick={() => setConfirmAction({ type: 'deactivate', student })}
+                                  >
+                                    <XCircleIcon className="size-4" />
+                                    Nonaktifkan
+                                  </DropdownMenuItem>
+                                )}
+                                {student.status === 'pending' && (
+                                  <DropdownMenuItem
+                                    variant="destructive"
+                                    onClick={() => setConfirmAction({ type: 'cancel', student })}
+                                  >
+                                    <BanIcon className="size-4" />
+                                    Batalkan
+                                  </DropdownMenuItem>
+                                )}
+                              </DropdownMenuGroup>
+                            </>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </TableCell>
                   </TableRow>
                 )

--- a/components/transfers/transfers-table.tsx
+++ b/components/transfers/transfers-table.tsx
@@ -1,11 +1,25 @@
 'use client'
 
 import { useState, useTransition, useCallback } from 'react'
-import { CheckCircleIcon, XCircleIcon, ExternalLinkIcon, EyeIcon } from 'lucide-react'
+import {
+  CheckCircleIcon,
+  XCircleIcon,
+  ExternalLinkIcon,
+  EyeIcon,
+  MoreHorizontalIcon,
+} from 'lucide-react'
 import { toast } from 'sonner'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import {
   Table,
   TableBody,
@@ -117,48 +131,48 @@ export function TransfersTable({
                       {formatDateWITA(transfer.issuedAt)}
                     </TableCell>
                     <TableCell className="text-right">
-                      <div className="flex justify-end gap-1.5 flex-wrap">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          render={<Link href={`${basePath}/${transfer.id}`} />}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          render={<Button variant="outline" size="icon-sm" />}
+                          disabled={isPending}
                         >
-                          <EyeIcon className="size-3.5 mr-1" />
-                          Detail
-                        </Button>
-                        {transfer.receiptFile && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            render={<a href={transfer.receiptFile} target="_blank" rel="noopener noreferrer" />}
-                          >
-                            <ExternalLinkIcon className="size-3.5 mr-1" />
-                            Bukti
-                          </Button>
-                        )}
-                        {canApproveCancel && transfer.status === 'pending' && (
-                          <>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setApproveTarget(transfer)}
-                              disabled={isPending}
-                            >
-                              <CheckCircleIcon className="size-3.5 mr-1" />
-                              Setujui
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setCancelTarget(transfer)}
-                              disabled={isPending}
-                            >
-                              <XCircleIcon className="size-3.5 mr-1" />
-                              Batalkan
-                            </Button>
-                          </>
-                        )}
-                      </div>
+                          <MoreHorizontalIcon className="size-4" />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-44">
+                          <DropdownMenuGroup>
+                            <DropdownMenuItem render={<Link href={`${basePath}/${transfer.id}`} />}>
+                              <EyeIcon className="size-4" />
+                              Lihat Detail
+                            </DropdownMenuItem>
+                            {transfer.receiptFile && (
+                              <DropdownMenuItem
+                                render={<a href={transfer.receiptFile} target="_blank" rel="noopener noreferrer" />}
+                              >
+                                <ExternalLinkIcon className="size-4" />
+                                Lihat Bukti
+                              </DropdownMenuItem>
+                            )}
+                          </DropdownMenuGroup>
+                          {canApproveCancel && transfer.status === 'pending' && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuGroup>
+                                <DropdownMenuItem onClick={() => setApproveTarget(transfer)}>
+                                  <CheckCircleIcon className="size-4" />
+                                  Setujui
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  variant="destructive"
+                                  onClick={() => setCancelTarget(transfer)}
+                                >
+                                  <XCircleIcon className="size-4" />
+                                  Batalkan
+                                </DropdownMenuItem>
+                              </DropdownMenuGroup>
+                            </>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </TableCell>
                   </TableRow>
                 )


### PR DESCRIPTION
## Terkait Issue
Closes #58

## Ringkasan Perubahan
- Semua tabel modul (students, transfers, institutes, fee-payments, staffs) menggunakan satu tombol `...` (DropdownMenu) menggantikan 2–5 tombol inline
- Aksi destruktif (nonaktifkan, batalkan, lepas akun) menggunakan `variant="destructive"` pada `DropdownMenuItem`
- Dialog konfirmasi yang sudah ada tetap dipertahankan, hanya trigger-nya yang dipindah ke DropdownMenuItem
- staffs-table: ganti `ToggleLeftIcon`/`ToggleRightIcon` dengan `PowerIcon`/`PowerOffIcon`
- Sheet form diperlebar: students/fee-payments/staffs `sm:max-w-lg` → `sm:max-w-xl`, fees `sm:max-w-md` → `sm:max-w-lg`
- Menggunakan pola `render` prop Base UI (bukan `asChild`) untuk `DropdownMenuTrigger` dan `DropdownMenuItem` dengan navigasi link

## Hasil Test Plan
```
pnpm tsc --noEmit  → exit 0 (tidak ada error TypeScript)
pnpm test          → 11 test files, 203 tests passed
```

## Checklist
- [x] Kolom aksi hanya tampilkan satu tombol ikon `...` di semua tabel
- [x] Aksi destruktif tampil merah di dropdown
- [x] Dialog konfirmasi masih dipertahankan
- [x] Sheet form diperlebar sesuai spesifikasi issue
- [x] Tidak ada TypeScript error (`pnpm tsc --noEmit` exit 0)
- [x] Semua 203 test passing
- [x] Tidak ada `any` di TypeScript
- [x] Tidak ada logika bisnis yang berubah