### PR TITLE
fix: pisahkan layout per route group untuk hilangkan double sidebar (#63)

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,54 +1,16 @@
 import { redirect } from 'next/navigation'
-import { requireAuth, getUserSubapps } from '@/lib/auth-helpers'
-import type { UserRole } from '@/lib/auth-helpers'
-import { Header } from '@/components/layout/header'
-import { SidebarDesktop } from '@/components/layout/sidebar'
+import { requireAuth } from '@/lib/auth-helpers'
 
 export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  let session: Awaited<ReturnType<typeof requireAuth>>
-
   try {
-    session = await requireAuth()
+    await requireAuth()
   } catch {
     redirect('/login')
   }
 
-  const { user } = session
-  const userRole = (user as { role?: UserRole }).role ?? 'user'
-
-  let subapps: Awaited<ReturnType<typeof getUserSubapps>> = []
-
-  if (userRole !== 'superadmin') {
-    try {
-      subapps = await getUserSubapps(user.id)
-    } catch {
-      // gagal fetch subapps — lanjut dengan list kosong
-      subapps = []
-    }
-  }
-
-  return (
-    <div className="flex min-h-screen">
-      {/* Desktop sidebar — fixed on left */}
-      <SidebarDesktop role={userRole} />
-
-      {/* Main content area */}
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <Header
-          userName={user.name}
-          userEmail={user.email}
-          userAvatar={(user as { avatar?: string | null }).avatar ?? null}
-          userRole={userRole}
-          subapps={subapps}
-          currentSubappKey={null}
-        />
-
-        <main className="flex-1 overflow-y-auto p-4 lg:p-6">{children}</main>
-      </div>
-    </div>
-  )
+  return <>{children}</>
 }

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -6,6 +6,7 @@ import type { UserRole } from '@/lib/auth-helpers'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
+import { Header } from '@/components/layout/header'
 import type { Subapp } from '@/lib/db/schema'
 
 const TYPE_LABEL: Record<string, string> = {
@@ -67,63 +68,76 @@ export default async function DashboardPortalPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Selamat Datang, {user.name}
-        </h1>
-        <p className="text-muted-foreground mt-1">
-          Pilih aplikasi yang ingin Anda akses.
-        </p>
-      </div>
+    <div className="flex min-h-screen flex-col">
+      <Header
+        userName={user.name}
+        userEmail={user.email}
+        userAvatar={(user as { avatar?: string | null }).avatar ?? null}
+        userRole={userRole}
+        subapps={subappList.filter((s) => s.type !== 'superadmin')}
+        currentSubappKey={null}
+      />
 
-      {subappList.length === 0 ? (
-        <p className="text-muted-foreground">
-          Anda belum memiliki akses ke sub-aplikasi manapun. Hubungi administrator.
-        </p>
-      ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {subappList.map((subapp) => (
-            <Card key={subapp.id} className="flex flex-col">
-              <CardHeader className="items-center pb-2">
-                {subapp.image ? (
-                  <div className="relative size-16 overflow-hidden rounded-full border">
-                    <Image
-                      src={subapp.image}
-                      alt={subapp.name ?? subapp.key}
-                      fill
-                      className="object-cover"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex size-16 items-center justify-center rounded-full border bg-muted text-2xl font-bold text-muted-foreground">
-                    {(subapp.name ?? subapp.key).slice(0, 1).toUpperCase()}
-                  </div>
-                )}
-              </CardHeader>
+      <main className="flex-1 overflow-y-auto p-4 lg:p-6">
+        <div className="flex flex-col gap-6">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Selamat Datang, {user.name}
+            </h1>
+            <p className="text-muted-foreground mt-1">
+              Pilih aplikasi yang ingin Anda akses.
+            </p>
+          </div>
 
-              <CardContent className="flex flex-1 flex-col items-center gap-2 text-center">
-                <p className="font-medium leading-tight">
-                  {subapp.name ?? subapp.key}
-                </p>
-                <Badge variant={TYPE_VARIANT[subapp.type] ?? 'outline'}>
-                  {TYPE_LABEL[subapp.type] ?? subapp.type}
-                </Badge>
-              </CardContent>
+          {subappList.length === 0 ? (
+            <p className="text-muted-foreground">
+              Anda belum memiliki akses ke sub-aplikasi manapun. Hubungi administrator.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {subappList.map((subapp) => (
+                <Card key={subapp.id} className="flex flex-col">
+                  <CardHeader className="items-center pb-2">
+                    {subapp.image ? (
+                      <div className="relative size-16 overflow-hidden rounded-full border">
+                        <Image
+                          src={subapp.image}
+                          alt={subapp.name ?? subapp.key}
+                          fill
+                          className="object-cover"
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex size-16 items-center justify-center rounded-full border bg-muted text-2xl font-bold text-muted-foreground">
+                        {(subapp.name ?? subapp.key).slice(0, 1).toUpperCase()}
+                      </div>
+                    )}
+                  </CardHeader>
 
-              <CardFooter className="justify-center pt-2">
-                <Button
-                  size="sm"
-                  className="w-full"
-                  render={<Link href={subappHref(subapp)} />}
-                >
-                  Masuk
-                </Button>
-              </CardFooter>
-            </Card>
-          ))}
+                  <CardContent className="flex flex-1 flex-col items-center gap-2 text-center">
+                    <p className="font-medium leading-tight">
+                      {subapp.name ?? subapp.key}
+                    </p>
+                    <Badge variant={TYPE_VARIANT[subapp.type] ?? 'outline'}>
+                      {TYPE_LABEL[subapp.type] ?? subapp.type}
+                    </Badge>
+                  </CardContent>
+
+                  <CardFooter className="justify-center pt-2">
+                    <Button
+                      size="sm"
+                      className="w-full"
+                      render={<Link href={subappHref(subapp)} />}
+                    >
+                      Masuk
+                    </Button>
+                  </CardFooter>
+                </Card>
+              ))}
+            </div>
+          )}
         </div>
-      )}
+      </main>
     </div>
   )
 }

--- a/app/(dashboard)/superadmin/layout.tsx
+++ b/app/(dashboard)/superadmin/layout.tsx
@@ -1,0 +1,46 @@
+import { redirect } from 'next/navigation'
+import { requireRole, getUserSubapps } from '@/lib/auth-helpers'
+import type { UserRole } from '@/lib/auth-helpers'
+import { Header } from '@/components/layout/header'
+import { SidebarDesktop } from '@/components/layout/sidebar'
+
+export default async function SuperadminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  let session: Awaited<ReturnType<typeof requireRole>>
+
+  try {
+    session = await requireRole(['superadmin'])
+  } catch {
+    redirect('/login')
+  }
+
+  const { user } = session
+  const userRole = (user as { role?: UserRole }).role ?? 'user'
+
+  let subapps: Awaited<ReturnType<typeof getUserSubapps>> = []
+  try {
+    subapps = await getUserSubapps(user.id)
+  } catch {
+    subapps = []
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <SidebarDesktop role={userRole} />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <Header
+          userName={user.name}
+          userEmail={user.email}
+          userAvatar={(user as { avatar?: string | null }).avatar ?? null}
+          userRole={userRole}
+          subapps={subapps}
+          currentSubappKey={null}
+        />
+        <main className="flex-1 overflow-y-auto p-4 lg:p-6">{children}</main>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Terkait Issue
Closes #63

## Ringkasan Perubahan
- `app/(dashboard)/layout.tsx` diubah menjadi pure auth wrapper — hanya validasi session via `requireAuth()`, tidak merender UI (sidebar/header) apapun
- Buat `app/(dashboard)/superadmin/layout.tsx` baru dengan sidebar+header khusus superadmin (menggunakan `requireRole(['superadmin'])`)
- `app/(dashboard)/page.tsx` (portal page) ditambahkan `<Header>` langsung karena parent layout tidak lagi menyediakan UI shell

## Root Cause
`(dashboard)/layout.tsx` sebelumnya merender `<SidebarDesktop>` + `<Header>` untuk semua route. Ketika route `foundation/[subAppKey]` dan `school/[subAppKey]` (yang sudah punya layout sendiri dengan sidebar+header) di-render di bawahnya, terjadi double sidebar.

## Hasil Test Plan
- `pnpm tsc --noEmit` — pass, tidak ada error TypeScript
- Route `/superadmin` — sidebar+header dari `superadmin/layout.tsx`, satu kali render
- Route `/foundation/[subAppKey]` — sidebar+header dari `foundation/[subAppKey]/layout.tsx`, satu kali render
- Route `/school/[subAppKey]` — sidebar+header dari `school/[subAppKey]/layout.tsx`, satu kali render
- Route `/` (portal) — hanya Header (tanpa sidebar, karena portal tidak butuh sidebar)

## Checklist
- [x] `(dashboard)/layout.tsx` diubah jadi pure auth wrapper
- [x] `superadmin/layout.tsx` dibuat dengan sidebar+header
- [x] Portal page embed Header langsung
- [x] Foundation dan school layout sudah ada sebelumnya — tidak perlu diubah
- [x] Tidak ada `any` di TypeScript
- [x] TypeScript check pass